### PR TITLE
Add local dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,15 @@ After applying the Terraform configuration, upload the contents of the `web`
 folder to the created bucket and replace the `STATUS_API_URL` and
 `START_API_URL` placeholders in `app.js` with the values from the Terraform
 outputs `status_minecraft_api_url` and `start_minecraft_api_url`.
+
+### Local Testing
+
+A helper script is provided for testing the web interface without AWS. Run:
+
+```
+python3 dev_server.py
+```
+
+This starts a server on `http://localhost:8000` that serves the files from the
+`web` directory and provides dummy endpoints at `/STATUS_API_URL` and
+`/START_API_URL`.

--- a/dev_server.py
+++ b/dev_server.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Simple development server for the web interface.
+
+Serves the files from the ``web`` directory and exposes dummy API endpoints
+for ``STATUS_API_URL`` and ``START_API_URL`` so the frontend can be tested
+locally without deploying any infrastructure.
+"""
+
+import http.server
+import json
+import os
+from functools import partial
+
+PORT = 8000
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/STATUS_API_URL':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            payload = {'state': 'running', 'players': 0}
+            self.wfile.write(json.dumps(payload).encode())
+            return
+        super().do_GET()
+
+    def do_POST(self):
+        if self.path == '/START_API_URL':
+            self.send_response(200)
+            self.end_headers()
+            return
+        self.send_error(404, 'Not Found')
+
+if __name__ == '__main__':
+    web_dir = os.path.join(os.path.dirname(__file__), 'web')
+    handler = partial(Handler, directory=web_dir)
+    with http.server.ThreadingHTTPServer(('localhost', PORT), handler) as httpd:
+        print(f'Serving at http://localhost:{PORT}')
+        httpd.serve_forever()


### PR DESCRIPTION
## Summary
- add a simple Python script to run the web interface locally
- document how to use the dev server in the README

## Testing
- `python3 -m py_compile terraform/lambda/start_minecraft.py`
- `python3 -m py_compile dev_server.py`
- ❌ `terraform fmt -check -recursive` *(failed: command not found)*
- ❌ `terraform -chdir=terraform init` *(failed: command not found)*
- ❌ `terraform -chdir=terraform validate` *(failed: command not found)*
- ❌ `shellcheck terraform/user_data.sh` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685449c41f288323a777b38bf4e90db3