### PR TITLE
Improve logging across components

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -9,13 +9,16 @@ locally without deploying any infrastructure.
 import http.server
 import json
 import os
+import logging
 from functools import partial
 
 PORT = 8000
 
+
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/STATUS_API_URL':
+            logging.info("Received status check request")
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
             self.end_headers()
@@ -26,14 +29,17 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 
     def do_POST(self):
         if self.path == '/START_API_URL':
+            logging.info("Received start server request")
             self.send_response(200)
             self.end_headers()
             return
+        logging.warning("Unknown POST path: %s", self.path)
         self.send_error(404, 'Not Found')
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
     web_dir = os.path.join(os.path.dirname(__file__), 'web')
     handler = partial(Handler, directory=web_dir)
     with http.server.ThreadingHTTPServer(('localhost', PORT), handler) as httpd:
-        print(f'Serving at http://localhost:{PORT}')
+        logging.info('Serving at http://localhost:%s', PORT)
         httpd.serve_forever()

--- a/terraform/lambda/start_minecraft.py
+++ b/terraform/lambda/start_minecraft.py
@@ -1,16 +1,25 @@
 import boto3
 import os
+import logging
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 def handler(event, context):
     instance_id = os.environ["INSTANCE_ID"]
     ec2 = boto3.client("ec2")
+    logger.info("Starting instance %s", instance_id)
+    logger.debug("Event received: %s", event)
     try:
         response = ec2.start_instances(InstanceIds=[instance_id])
+        logger.info("Start response: %s", response)
         return {
             "statusCode": 200,
             "body": f"Starting instance {instance_id}: {response}"
         }
     except Exception as e:
+        logger.exception("Error starting instance %s", instance_id)
         return {
             "statusCode": 500,
             "body": f"Error starting instance {instance_id}: {e}"

--- a/terraform/lambda/status_minecraft.py
+++ b/terraform/lambda/status_minecraft.py
@@ -2,6 +2,11 @@ import boto3
 import os
 import json
 import urllib.request
+import logging
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 INSTANCE_ID = os.environ.get("INSTANCE_ID")
 SERVER_IP = os.environ.get("SERVER_IP")
@@ -9,10 +14,13 @@ SERVER_IP = os.environ.get("SERVER_IP")
 ec2 = boto3.client("ec2")
 
 def handler(event, context):
+    logger.debug("Status request event: %s", event)
     try:
         resp = ec2.describe_instances(InstanceIds=[INSTANCE_ID])
         state = resp["Reservations"][0]["Instances"][0]["State"]["Name"]
+        logger.info("Instance %s state: %s", INSTANCE_ID, state)
     except Exception as e:
+        logger.exception("Error describing instance %s", INSTANCE_ID)
         return {"statusCode": 500, "body": json.dumps({"error": str(e)})}
 
     players = None
@@ -21,7 +29,9 @@ def handler(event, context):
             with urllib.request.urlopen(f"https://api.mcstatus.io/v2/status/java/{SERVER_IP}") as f:
                 data = json.load(f)
                 players = data.get("players", {}).get("online")
-        except Exception:
+                logger.info("Online players: %s", players)
+        except Exception as e:
+            logger.warning("Failed to query player count: %s", e)
             players = None
 
     return {

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 # This variable is replaced by Terraform at deploy time
 # shellcheck disable=SC2269
 BACKUP_BUCKET="${BACKUP_BUCKET}"
+
+LOG_FILE=/var/log/minecraft-setup.log
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 yum update -y
 
 # Create a 2 GB swap file
@@ -120,6 +125,8 @@ echo "0 3 * * * /home/ec2-user/minecraft/backup.sh" | sudo tee -a /var/spool/cro
 # Create idle check script
 cat << 'EOF' > /home/ec2-user/minecraft/idle-check.sh
 #!/bin/bash
+set -euo pipefail
+exec >> /var/log/minecraft-idle.log 2>&1
 
 RCON_HOST="127.0.0.1"
 RCON_PORT=25575


### PR DESCRIPTION
## Summary
- add Python logging in Lambda functions
- log requests in the dev server
- capture setup output in `user_data.sh`
- log idle-check script output

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `shellcheck terraform/user_data.sh`
- `python3 -m py_compile terraform/lambda/start_minecraft.py terraform/lambda/status_minecraft.py`


------
https://chatgpt.com/codex/tasks/task_e_6854740673088323807a5a5f7028fe63