### PR TITLE
Add Terraform SaaS scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ python3 dev_server.py
 This starts a server on `http://localhost:8000` that serves the files from the
 `web` directory and provides dummy endpoints at `/STATUS_API_URL` and
 `/START_API_URL`.
+
+## SaaS Architecture
+
+A design proposal for running each tenant in a separate AWS account is available in [docs/saas_layer.md](docs/saas_layer.md).
+
+The `saas` directory contains Terraform configuration for creating tenant AWS accounts and a Cognito user pool for authentication. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and update the values before running `terraform -chdir=saas apply` from a management account that has access to AWS Organizations.

--- a/docs/saas_layer.md
+++ b/docs/saas_layer.md
@@ -1,0 +1,20 @@
+# SaaS Architecture Overview
+
+This document outlines a high level plan for supporting a multi‑tenant setup where each customer runs their Minecraft server in an isolated AWS account created with Terraform.
+
+## Account Creation
+- Use the `aws_organizations_account` resource from the AWS provider to create a new member account for each tenant.
+- After creation, Terraform can assume an IAM role in the new account (e.g. `OrganizationAccountAccessRole`) to deploy the server infrastructure.
+- Each tenant account receives its own VPC, EC2 instance and web bucket. An Elastic IP is allocated so the server address stays constant.
+
+## Authentication
+- Central authentication can be provided by Amazon Cognito in the management account.
+- The web interface authenticates users and stores a tenant identifier (e.g. Cognito groups or a tenant table) so API requests target the correct account.
+
+## Billing with Stripe
+- Usage metrics (like server uptime or data transfer) should be aggregated in the management account using CloudWatch or AWS Cost Explorer.
+- A billing service periodically reports usage to Stripe to invoice customers. Webhooks from Stripe can update account status (e.g. suspend on failed payment).
+
+## Future Work
+- Implement Terraform modules for account creation and per‑tenant infrastructure.
+- Add automation for provisioning DNS and SSL certificates.

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -1,0 +1,25 @@
+module "tenant_account" {
+  source        = "./modules/tenant_account"
+  account_name  = var.tenant_account_name
+  account_email = var.tenant_account_email
+  tenant_id     = var.tenant_id
+  region        = var.region
+}
+
+module "auth" {
+  source         = "./modules/auth"
+  user_pool_name = var.user_pool_name
+  client_name    = var.client_name
+}
+
+output "tenant_account_id" {
+  value = module.tenant_account.tenant_account_id
+}
+
+output "user_pool_id" {
+  value = module.auth.user_pool_id
+}
+
+output "user_pool_client_id" {
+  value = module.auth.user_pool_client_id
+}

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -1,0 +1,17 @@
+resource "aws_cognito_user_pool" "this" {
+  name = var.user_pool_name
+}
+
+resource "aws_cognito_user_pool_client" "this" {
+  name                = var.client_name
+  user_pool_id        = aws_cognito_user_pool.this.id
+  explicit_auth_flows = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+}
+
+output "user_pool_id" {
+  value = aws_cognito_user_pool.this.id
+}
+
+output "user_pool_client_id" {
+  value = aws_cognito_user_pool_client.this.id
+}

--- a/saas/modules/auth/variables.tf
+++ b/saas/modules/auth/variables.tf
@@ -1,0 +1,7 @@
+variable "user_pool_name" {
+  type = string
+}
+
+variable "client_name" {
+  type = string
+}

--- a/saas/modules/auth/versions.tf
+++ b/saas/modules/auth/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/saas/modules/tenant_account/main.tf
+++ b/saas/modules/tenant_account/main.tf
@@ -1,0 +1,22 @@
+resource "aws_organizations_account" "this" {
+  name              = var.account_name
+  email             = var.account_email
+  close_on_deletion = true
+}
+
+provider "aws" {
+  alias  = "tenant"
+  region = var.region
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.this.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+resource "aws_s3_bucket" "web" {
+  provider = aws.tenant
+  bucket   = "minecraft-web-${var.tenant_id}"
+}
+
+output "tenant_account_id" {
+  value = aws_organizations_account.this.id
+}

--- a/saas/modules/tenant_account/variables.tf
+++ b/saas/modules/tenant_account/variables.tf
@@ -1,0 +1,16 @@
+variable "account_name" {
+  type = string
+}
+
+variable "account_email" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "tenant_id" {
+  type = string
+}

--- a/saas/modules/tenant_account/versions.tf
+++ b/saas/modules/tenant_account/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/saas/terraform.tfvars.example
+++ b/saas/terraform.tfvars.example
@@ -1,0 +1,3 @@
+tenant_account_name  = "example-tenant"
+tenant_account_email = "example+tenant@example.com"
+tenant_id            = "example"

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -1,0 +1,26 @@
+variable "tenant_account_name" {
+  type = string
+}
+
+variable "tenant_account_email" {
+  type = string
+}
+
+variable "tenant_id" {
+  type = string
+}
+
+variable "user_pool_name" {
+  type    = string
+  default = "minecraft-saas-users"
+}
+
+variable "client_name" {
+  type    = string
+  default = "minecraft-web"
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}

--- a/saas/versions.tf
+++ b/saas/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement Terraform modules for creating tenant AWS accounts via Organizations
- add a module for Cognito user pool and client
- provide root config under `saas` directory with example tfvars
- update README with basic instructions

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform init -upgrade`
- `terraform -chdir=terraform validate`
- `shellcheck terraform/user_data.sh`
- `python3 -m py_compile terraform/lambda/start_minecraft.py terraform/lambda/status_minecraft.py`
- `terraform -chdir=saas init -upgrade`
- `terraform -chdir=saas validate`


------
https://chatgpt.com/codex/tasks/task_e_68547ad603748323848f6ae6dcbda529