### PR TITLE
Add SaaS landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ This starts a server on `http://localhost:8000` that serves the files from the
 A design proposal for running each tenant in a separate AWS account is available in [docs/saas_layer.md](docs/saas_layer.md).
 
 The `saas` directory contains Terraform configuration for creating tenant AWS accounts and a Cognito user pool for authentication. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and update the values before running `terraform -chdir=saas apply` from a management account that has access to AWS Organizations.
+
+### SaaS Landing Page
+
+The `saas_web` folder holds a small landing page used for the main SaaS sign‑up
+site. Terraform creates an S3 bucket and CloudFront distribution when
+`frontend_bucket_name` is set. Upload the contents of `saas_web` to that bucket
+and update `SIGNUP_API_URL` in `saas_web/app.js` to point at the future signup
+API endpoint.

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -12,6 +12,11 @@ module "auth" {
   client_name    = var.client_name
 }
 
+module "frontend_site" {
+  source      = "./modules/frontend_site"
+  bucket_name = var.frontend_bucket_name
+}
+
 output "tenant_account_id" {
   value = module.tenant_account.tenant_account_id
 }
@@ -22,4 +27,12 @@ output "user_pool_id" {
 
 output "user_pool_client_id" {
   value = module.auth.user_pool_client_id
+}
+
+output "frontend_bucket" {
+  value = module.frontend_site.bucket_name
+}
+
+output "frontend_url" {
+  value = module.frontend_site.cloudfront_domain
 }

--- a/saas/modules/frontend_site/main.tf
+++ b/saas/modules/frontend_site/main.tf
@@ -1,0 +1,65 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_website_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  index_document {
+    suffix = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_policy" "public" {
+  bucket = aws_s3_bucket.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["s3:GetObject"]
+      Resource  = "${aws_s3_bucket.this.arn}/*"
+    }]
+  })
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name = aws_s3_bucket.this.bucket_regional_domain_name
+    origin_id   = "s3-frontend"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-frontend"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+  }
+
+  price_class = "PriceClass_100"
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}
+
+output "cloudfront_domain" {
+  value = aws_cloudfront_distribution.this.domain_name
+}

--- a/saas/modules/frontend_site/variables.tf
+++ b/saas/modules/frontend_site/variables.tf
@@ -1,0 +1,3 @@
+variable "bucket_name" {
+  type = string
+}

--- a/saas/modules/frontend_site/versions.tf
+++ b/saas/modules/frontend_site/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/saas/terraform.tfvars.example
+++ b/saas/terraform.tfvars.example
@@ -1,3 +1,4 @@
 tenant_account_name  = "example-tenant"
 tenant_account_email = "example+tenant@example.com"
 tenant_id            = "example"
+frontend_bucket_name = "example-landing-bucket"

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -24,3 +24,7 @@ variable "region" {
   type    = string
   default = "us-east-1"
 }
+
+variable "frontend_bucket_name" {
+  type = string
+}

--- a/saas_web/app.js
+++ b/saas_web/app.js
@@ -1,0 +1,23 @@
+const form = document.getElementById('signup-form');
+const messageDiv = document.getElementById('signup-message');
+
+// Replace with the real signup endpoint when available
+const SIGNUP_URL = 'SIGNUP_API_URL';
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  messageDiv.textContent = 'Signing you up...';
+  const email = document.getElementById('email').value;
+  try {
+    const res = await fetch(SIGNUP_URL, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ email })
+    });
+    if (!res.ok) throw new Error('Failed');
+    messageDiv.textContent = 'Check your email to complete signup.';
+  } catch (err) {
+    console.error(err);
+    messageDiv.textContent = 'Signup failed. Please try again later.';
+  }
+});

--- a/saas_web/index.html
+++ b/saas_web/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Minecraft for All</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Minecraft for All</h1>
+    <p id="tagline">Run your own dedicated Minecraft server in minutes.</p>
+  </header>
+  <main>
+    <section>
+      <h2>Why choose us?</h2>
+      <p>We handle the boring stuff so you can focus on playing with your friends. Each server runs
+        in its own AWS account for maximum isolation, and you only pay for the time your server is
+        online.</p>
+    </section>
+    <section>
+      <h2>Sign up for early access</h2>
+      <form id="signup-form">
+        <input type="email" id="email" placeholder="you@example.com" required />
+        <button type="submit">Sign Up</button>
+      </form>
+      <div id="signup-message"></div>
+    </section>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/saas_web/styles.css
+++ b/saas_web/styles.css
@@ -1,0 +1,42 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  padding: 20px 0;
+  text-align: center;
+}
+
+main {
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 0 20px;
+}
+
+section {
+  margin-bottom: 40px;
+}
+
+form {
+  display: flex;
+  gap: 10px;
+}
+
+input {
+  flex: 1;
+  padding: 8px;
+}
+
+button {
+  padding: 8px 16px;
+}
+
+#signup-message {
+  margin-top: 10px;
+  color: green;
+}


### PR DESCRIPTION
## Summary
- provide a minimal landing page in `saas_web`
- create `frontend_site` Terraform module for S3/CloudFront hosting
- wire module into SaaS configuration and outputs
- document how to deploy the landing page

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`
- `shellcheck terraform/user_data.sh`
- `python3 -m py_compile terraform/lambda/start_minecraft.py terraform/lambda/status_minecraft.py`


------
https://chatgpt.com/codex/tasks/task_e_6854850008a883239544f3083267f02d