### PR TITLE
Add SaaS website setup guide and provisioning lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ This starts a server on `http://localhost:8000` that serves the files from the
 
 A design proposal for running each tenant in a separate AWS account is available in [docs/saas_layer.md](docs/saas_layer.md).
 
+Step-by-step instructions for deploying the SaaS site and tenant provisioning Lambda are provided in [docs/saas_setup.md](docs/saas_setup.md).
+
 The `saas` directory contains Terraform configuration for creating tenant AWS accounts and a Cognito user pool for authentication. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and update the values before running `terraform -chdir=saas apply` from a management account that has access to AWS Organizations.
 
 ### SaaS Landing Page
@@ -79,3 +81,13 @@ site. Terraform creates an S3 bucket and CloudFront distribution when
 `frontend_bucket_name` is set. Upload the contents of `saas_web` to that bucket
 and update `SIGNUP_API_URL` in `saas_web/app.js` to point at the future signup
 API endpoint.
+
+To run the SaaS site locally, use the development server with the `--site`
+option:
+
+```bash
+python3 dev_server.py --site saas_web
+```
+
+This serves the files from `saas_web` and mocks a `/SIGNUP_API_URL` endpoint so
+the form can be tested without deploying any backend.

--- a/dev_server.py
+++ b/dev_server.py
@@ -1,45 +1,71 @@
 #!/usr/bin/env python3
-"""Simple development server for the web interface.
+"""Simple development server for the web interfaces.
 
-Serves the files from the ``web`` directory and exposes dummy API endpoints
-for ``STATUS_API_URL`` and ``START_API_URL`` so the frontend can be tested
-locally without deploying any infrastructure.
+By default it serves the files from the ``web`` directory and exposes dummy
+API endpoints so the frontend can be tested locally without deploying any
+infrastructure. Pass ``--site saas_web`` to serve the SaaS landing page and
+mock its signup endpoint.
 """
 
 import http.server
 import json
 import os
 import logging
+import argparse
 from functools import partial
 
 PORT = 8000
 
 
+MOCK_RESPONSES = {}
+
+
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
-        if self.path == '/STATUS_API_URL':
-            logging.info("Received status check request")
-            self.send_response(200)
-            self.send_header('Content-Type', 'application/json')
+        resp = MOCK_RESPONSES.get(("GET", self.path))
+        if resp:
+            status, body = resp
+            self.send_response(status)
+            if body is not None:
+                self.send_header("Content-Type", "application/json")
             self.end_headers()
-            payload = {'state': 'running', 'players': 0}
-            self.wfile.write(json.dumps(payload).encode())
+            if body is not None:
+                self.wfile.write(json.dumps(body).encode())
             return
         super().do_GET()
 
     def do_POST(self):
-        if self.path == '/START_API_URL':
-            logging.info("Received start server request")
-            self.send_response(200)
+        resp = MOCK_RESPONSES.get(("POST", self.path))
+        if resp:
+            status, body = resp
+            self.send_response(status)
+            if body is not None:
+                self.send_header("Content-Type", "application/json")
             self.end_headers()
+            if body is not None:
+                self.wfile.write(json.dumps(body).encode())
             return
         logging.warning("Unknown POST path: %s", self.path)
-        self.send_error(404, 'Not Found')
+        self.send_error(404, "Not Found")
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Development server for the web UIs")
+    parser.add_argument('--site', choices=['web', 'saas_web'], default='web', help='Which site to serve')
+    args = parser.parse_args()
+
+    if args.site == 'web':
+        MOCK_RESPONSES.update({
+            ('GET', '/STATUS_API_URL'): (200, {'state': 'running', 'players': 0}),
+            ('POST', '/START_API_URL'): (200, None),
+        })
+    else:
+        MOCK_RESPONSES.update({
+            ('POST', '/SIGNUP_API_URL'): (200, None),
+        })
+
     logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
-    web_dir = os.path.join(os.path.dirname(__file__), 'web')
+    web_dir = os.path.join(os.path.dirname(__file__), args.site)
     handler = partial(Handler, directory=web_dir)
-    with http.server.ThreadingHTTPServer(('localhost', PORT), handler) as httpd:
-        logging.info('Serving at http://localhost:%s', PORT)
+    with http.server.ThreadingHTTPServer(("localhost", PORT), handler) as httpd:
+        logging.info('Serving %s at http://localhost:%s', args.site, PORT)
         httpd.serve_forever()

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -1,0 +1,42 @@
+# SaaS Website Setup
+
+This guide explains how to deploy the SaaS landing page and how new tenants are
+provisioned when a user confirms their account.
+
+## Deploying the Website
+
+1. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and set the
+   required values. The `frontend_bucket_name` variable controls where the site
+   will be hosted.
+2. Run `terraform -chdir=saas init` followed by `terraform -chdir=saas apply` from
+   an AWS account with access to AWS Organizations. This creates the user pool
+   and S3 bucket/CloudFront distribution for the website.
+3. Upload the contents of the `saas_web` directory to the created S3 bucket and
+   update `SIGNUP_API_URL` in `saas_web/app.js` to point at your signup API.
+
+## Local Development
+
+To test the SaaS site locally without any AWS resources run:
+
+```bash
+python3 dev_server.py --site saas_web
+```
+
+This serves the landing page at <http://localhost:8000> and mocks a
+`/SIGNUP_API_URL` endpoint so the signup form works offline.
+
+## Tenant Provisioning Lambda
+
+The `create_tenant` Lambda function (`saas/lambda/create_tenant.py`) is attached
+as a *post confirmation* trigger on the Cognito user pool. When a new user
+confirms their account the function uses the AWS Organizations API to create a
+fresh member account for that tenant.
+
+The function currently performs the following steps:
+
+1. Read the confirmed user's email from the event.
+2. Generate a short tenant identifier.
+3. Call `organizations.create_account` with the email and a default account name.
+
+The `saas` Terraform code builds and deploys this Lambda automatically and
+grants the user pool permission to invoke it.

--- a/saas/lambda/create_tenant.py
+++ b/saas/lambda/create_tenant.py
@@ -1,0 +1,29 @@
+import boto3
+import json
+import logging
+import uuid
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+org = boto3.client("organizations")
+
+def handler(event, context):
+    """Create a new tenant account when a user is confirmed."""
+    logger.debug("Received event: %s", event)
+    try:
+        email = event["request"]["userAttributes"]["email"]
+    except KeyError:
+        logger.error("Email not found in event")
+        return {"statusCode": 400, "body": "Missing email"}
+
+    tenant_id = str(uuid.uuid4())[:8]
+    account_name = f"minecraft-{tenant_id}"
+    try:
+        resp = org.create_account(Email=email, AccountName=account_name)
+        create_id = resp["CreateAccountStatus"]["Id"]
+        logger.info("Started account creation %s for %s", create_id, email)
+        return {"statusCode": 200, "body": json.dumps({"create_id": create_id, "tenant_id": tenant_id})}
+    except Exception as e:
+        logger.exception("Failed to create account for %s", email)
+        return {"statusCode": 500, "body": str(e)}

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -1,11 +1,63 @@
 resource "aws_cognito_user_pool" "this" {
   name = var.user_pool_name
+
+  lambda_config {
+    post_confirmation = aws_lambda_function.create_tenant.arn
+  }
 }
 
 resource "aws_cognito_user_pool_client" "this" {
   name                = var.client_name
   user_pool_id        = aws_cognito_user_pool.this.id
   explicit_auth_flows = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "create-tenant-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action    = "sts:AssumeRole",
+      Effect    = "Allow",
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+
+  inline_policy {
+    name = "create-tenant"
+    policy = jsonencode({
+      Version = "2012-10-17",
+      Statement = [{
+        Effect   = "Allow",
+        Action   = ["organizations:CreateAccount"],
+        Resource = "*"
+      }]
+    })
+  }
+}
+
+data "archive_file" "lambda_create_tenant" {
+  type        = "zip"
+  source_file = "${path.module}/../../lambda/create_tenant.py"
+  output_path = "${path.module}/lambda_create_tenant.zip"
+}
+
+resource "aws_lambda_function" "create_tenant" {
+  filename         = data.archive_file.lambda_create_tenant.output_path
+  source_code_hash = data.archive_file.lambda_create_tenant.output_base64sha256
+  function_name    = "create-tenant"
+  role             = aws_iam_role.lambda.arn
+  handler          = "create_tenant.handler"
+  runtime          = "python3.11"
+  timeout          = 30
+}
+
+resource "aws_lambda_permission" "allow_cognito" {
+  statement_id  = "AllowCognitoInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.create_tenant.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.this.arn
 }
 
 output "user_pool_id" {


### PR DESCRIPTION
## Summary
- document how to deploy the SaaS site and tenant provisioning lambda
- mention new instructions in README
- allow `dev_server.py` to serve the SaaS landing page
- create new Lambda `create_tenant` and wire it to Cognito

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `shellcheck terraform/user_data.sh`
- `python3 -m py_compile terraform/lambda/start_minecraft.py`
- `python3 -m py_compile saas/lambda/create_tenant.py`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`

------
https://chatgpt.com/codex/tasks/task_e_6854ad5c0d7c8323982e06b1fa29b205