### PR TITLE
Add login and console pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ Step-by-step instructions for deploying the SaaS site and tenant provisioning La
 
 The `saas` directory contains Terraform configuration for creating tenant AWS accounts and a Cognito user pool for authentication. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and update the values before running `terraform -chdir=saas apply` from a management account that has access to AWS Organizations.
 
-### SaaS Landing Page
+### SaaS Website
 
-The `saas_web` folder holds a small landing page used for the main SaaS sign‑up
-site. Terraform creates an S3 bucket and CloudFront distribution when
-`frontend_bucket_name` is set. Upload the contents of `saas_web` to that bucket
-and update `SIGNUP_API_URL` in `saas_web/app.js` to point at the future signup
-API endpoint.
+The `saas_web` folder now contains the main SaaS site with signup, login and a
+simple management console. Terraform creates an S3 bucket and CloudFront
+distribution when `frontend_bucket_name` is set. Upload the contents of
+`saas_web` to that bucket and update the `*_API_URL` placeholders in the Vue
+components to point at your backend APIs.
 
 To run the SaaS site locally, use the development server with the `--site`
 option:
@@ -84,5 +84,5 @@ option:
 python3 dev_server.py --site saas_web
 ```
 
-This serves the files from `saas_web` and mocks a `/SIGNUP_API_URL` endpoint so
-the form can be tested without deploying any backend.
+This serves the files from `saas_web` and mocks the various API endpoints so the
+forms and console can be tested without deploying any backend.

--- a/dev_server.py
+++ b/dev_server.py
@@ -61,6 +61,9 @@ if __name__ == '__main__':
     else:
         MOCK_RESPONSES.update({
             ('POST', '/SIGNUP_API_URL'): (200, None),
+            ('POST', '/LOGIN_API_URL'): (200, {'token': 'dummy'}),
+            ('GET', '/STATUS_API_URL'): (200, {'state': 'offline'}),
+            ('POST', '/START_API_URL'): (200, None),
         })
 
     logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -12,7 +12,8 @@ provisioned when a user confirms their account.
    an AWS account with access to AWS Organizations. This creates the user pool
    and S3 bucket/CloudFront distribution for the website.
 3. Upload the contents of the `saas_web` directory to the created S3 bucket and
-   update `SIGNUP_API_URL` in `saas_web/app.js` to point at your signup API.
+   update the `*_API_URL` placeholders inside the Vue components to point at your
+   deployed APIs.
 
 ## Local Development
 
@@ -22,8 +23,8 @@ To test the SaaS site locally without any AWS resources run:
 python3 dev_server.py --site saas_web
 ```
 
-This serves the landing page at <http://localhost:8000> and mocks a
-`/SIGNUP_API_URL` endpoint so the signup form works offline.
+This serves the site at <http://localhost:8000> and mocks all API endpoints so
+signup, login and the console work offline.
 
 ## Tenant Provisioning Lambda
 

--- a/saas_web/components/App.vue
+++ b/saas_web/components/App.vue
@@ -8,6 +8,8 @@
       <v-btn to="/pricing" variant="text" router>Pricing</v-btn>
       <v-btn to="/support" variant="text" router>Support</v-btn>
       <v-btn to="/about" variant="text" router>About Us</v-btn>
+      <v-btn to="/login" variant="text" router>Login</v-btn>
+      <v-btn to="/console" variant="text" router>Console</v-btn>
       <v-btn to="/start" color="primary" router>Start</v-btn>
     </v-app-bar>
     <v-main class="py-4">

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h2 class="text-h5 mb-4">Server Console</h2>
+        <div>{{ status }}</div>
+        <v-btn v-if="showStart" @click="start" class="mt-2">Start Server</v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'Console',
+  data() {
+    return {
+      status: 'Checking status...',
+      showStart: false,
+      interval: null,
+    };
+  },
+  mounted() {
+    this.fetchStatus();
+    this.interval = setInterval(this.fetchStatus, 30000);
+  },
+  beforeUnmount() {
+    clearInterval(this.interval);
+  },
+  methods: {
+    authHeader() {
+      const token = localStorage.getItem('token');
+      return token ? { Authorization: `Bearer ${token}` } : {};
+    },
+    async fetchStatus() {
+      try {
+        const res = await fetch('STATUS_API_URL', { headers: this.authHeader() });
+        const data = await res.json();
+        if (data.state === 'running') {
+          const players = data.players ?? 0;
+          this.status = `Server is running with ${players} player${players === 1 ? '' : 's'} online.`;
+          this.showStart = false;
+        } else {
+          this.status = 'Server is offline.';
+          this.showStart = true;
+        }
+      } catch (err) {
+        console.error(err);
+        this.status = 'Error fetching status.';
+      }
+    },
+    async start() {
+      this.showStart = false;
+      this.status = 'Starting...';
+      try {
+        const res = await fetch('START_API_URL', { method: 'POST', headers: this.authHeader() });
+        if (!res.ok) throw new Error('Failed');
+      } catch (err) {
+        console.error(err);
+        this.status = 'Could not start server.';
+        this.showStart = true;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="6" lg="4">
+        <h2 class="text-h5 mb-4">Login</h2>
+        <v-form @submit.prevent="submit">
+          <v-text-field v-model="email" label="Email" type="email" required></v-text-field>
+          <v-text-field v-model="password" label="Password" type="password" required></v-text-field>
+          <v-btn type="submit" color="deep-purple-accent-2" class="mt-2">Login</v-btn>
+        </v-form>
+        <div class="mt-2">{{ message }}</div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'Login',
+  data() {
+    return {
+      email: '',
+      password: '',
+      message: '',
+    };
+  },
+  methods: {
+    async submit() {
+      this.message = 'Logging in...';
+      try {
+        const res = await fetch('LOGIN_API_URL', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: this.email, password: this.password }),
+        });
+        if (!res.ok) throw new Error('Failed');
+        const data = await res.json();
+        localStorage.setItem('token', data.token);
+        this.message = 'Logged in!';
+        this.$router.push('/console');
+      } catch (err) {
+        console.error(err);
+        this.message = 'Login failed. Please try again later.';
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -26,6 +26,8 @@ const options = {
       { path: '/pricing', component: () => window['vue3-sfc-loader'].loadModule('./components/Pricing.vue', options) },
       { path: '/support', component: () => window['vue3-sfc-loader'].loadModule('./components/Support.vue', options) },
       { path: '/about', component: () => window['vue3-sfc-loader'].loadModule('./components/About.vue', options) },
+      { path: '/login', component: () => window['vue3-sfc-loader'].loadModule('./components/Login.vue', options) },
+      { path: '/console', component: () => window['vue3-sfc-loader'].loadModule('./components/Console.vue', options) },
       { path: '/start', component: () => window['vue3-sfc-loader'].loadModule('./components/Start.vue', options) },
     ],
   });


### PR DESCRIPTION
## Summary
- update SaaS docs to describe new auth based website
- add login and server console components
- expand router and navigation
- mock additional endpoints in dev_server

## Testing
- `pip install html5validator`
- `html5validator --root saas_web`
- `python3 -m py_compile saas/lambda/create_tenant.py`
- `python3 -m py_compile terraform/lambda/start_minecraft.py`
- `shellcheck terraform/user_data.sh`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`


------
https://chatgpt.com/codex/tasks/task_e_6855a5b5a8f4832391e2a9ea42d7442b