### PR TITLE
Add tenant cost reporting lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A design proposal for running each tenant in a separate AWS account is available
 
 Step-by-step instructions for deploying the SaaS site and tenant provisioning Lambda are provided in [docs/saas_setup.md](docs/saas_setup.md).
 
-The `saas` directory contains Terraform configuration for the Cognito user pool, the tenant provisioning Lambda and the landing site. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and set `frontend_bucket_name` before running `terraform -chdir=saas apply` from a management account that has access to AWS Organizations. Tenant accounts are created later when users sign up.
+The `saas` directory contains Terraform configuration for creating tenant AWS accounts and a Cognito user pool for authentication. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and update the values. Run `terraform -chdir=saas init` once to download the providers and modules, then you can use `terraform -chdir=saas validate` or `terraform -chdir=saas apply` from a management account that has access to AWS Organizations.
 
 ### SaaS Website
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ The `saas` directory contains Terraform configuration for creating tenant AWS ac
 The `saas_web` folder now contains the main SaaS site with signup, login and a
 simple management console. Terraform creates an S3 bucket and CloudFront
 distribution when `frontend_bucket_name` is set. Upload the contents of
-`saas_web` to that bucket and update the `*_API_URL` placeholders in the Vue
-components to point at your backend APIs.
+`saas_web` to that bucket and update the `*_API_URL` placeholders (including
+`COST_API_URL`) in the Vue components to point at your backend APIs.
+
+The Terraform outputs include `cost_api_url`, which points at a Lambda-powered
+endpoint in each tenant account that returns the current month's cost
+information.
 
 To run the SaaS site locally, use the development server with the `--site`
 option:
@@ -85,4 +89,5 @@ python3 dev_server.py --site saas_web
 ```
 
 This serves the files from `saas_web` and mocks the various API endpoints so the
-forms and console can be tested without deploying any backend.
+forms and console can be tested without deploying any backend, including a dummy
+`/COST_API_URL` used on the console page.

--- a/dev_server.py
+++ b/dev_server.py
@@ -4,7 +4,8 @@
 By default it serves the files from the ``web`` directory and exposes dummy
 API endpoints so the frontend can be tested locally without deploying any
 infrastructure. Pass ``--site saas_web`` to serve the SaaS landing page and
-mock its signup endpoint.
+mock its signup endpoint. The SaaS mode also provides a mock cost endpoint
+used by the console page.
 """
 
 import http.server
@@ -64,6 +65,13 @@ if __name__ == '__main__':
             ('POST', '/LOGIN_API_URL'): (200, {'token': 'dummy'}),
             ('GET', '/STATUS_API_URL'): (200, {'state': 'offline'}),
             ('POST', '/START_API_URL'): (200, None),
+            ('GET', '/COST_API_URL'): (200, {
+                'total': 12.34,
+                'breakdown': {
+                    'EC2': 10.00,
+                    'S3': 2.34,
+                }
+            }),
         })
 
     logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -12,8 +12,8 @@ provisioned when a user confirms their account.
    an AWS account with access to AWS Organizations. This creates the user pool
    and S3 bucket/CloudFront distribution for the website.
 3. Upload the contents of the `saas_web` directory to the created S3 bucket and
-   update the `*_API_URL` placeholders inside the Vue components to point at your
-   deployed APIs.
+   update the `*_API_URL` placeholders (including `COST_API_URL`) inside the Vue
+   components to point at your deployed APIs.
 
 ## Local Development
 
@@ -24,7 +24,8 @@ python3 dev_server.py --site saas_web
 ```
 
 This serves the site at <http://localhost:8000> and mocks all API endpoints so
-signup, login and the console work offline.
+signup, login and the console work offline, including a fake cost API used on
+the console page.
 
 ## Tenant Provisioning Lambda
 
@@ -41,3 +42,12 @@ The function currently performs the following steps:
 
 The `saas` Terraform code builds and deploys this Lambda automatically and
 grants the user pool permission to invoke it.
+
+## Cost Reporting Lambda
+
+Each tenant account also includes a simple `cost_report` Lambda function that is
+exposed through an API Gateway endpoint. This function queries the AWS Cost
+Explorer API for the current month's charges and returns the total along with a
+breakdown by service. The endpoint URL is output as `cost_api_url` when the
+Terraform code is applied and should be used to replace the `COST_API_URL`
+placeholder in the Vue console component.

--- a/saas/lambda/cost_report.py
+++ b/saas/lambda/cost_report.py
@@ -1,0 +1,33 @@
+import boto3
+import json
+from datetime import date
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ce = boto3.client("ce")
+
+def handler(event, context):
+    """Return this month's accumulated cost for the account."""
+    today = date.today()
+    start = today.replace(day=1).strftime("%Y-%m-%d")
+    end = today.strftime("%Y-%m-%d")
+    try:
+        resp = ce.get_cost_and_usage(
+            TimePeriod={"Start": start, "End": end},
+            Granularity="MONTHLY",
+            Metrics=["UnblendedCost"],
+            GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
+        )
+    except Exception:
+        logger.exception("Failed to query cost explorer")
+        return {"statusCode": 500, "body": json.dumps({"error": "Could not retrieve cost"})}
+
+    result = resp["ResultsByTime"][0]
+    total = float(result["Total"]["UnblendedCost"]["Amount"])
+    breakdown = {
+        g["Keys"][0]: float(g["Metrics"]["UnblendedCost"]["Amount"])
+        for g in result.get("Groups", [])
+    }
+    return {"statusCode": 200, "body": json.dumps({"total": total, "breakdown": breakdown})}

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -17,6 +17,10 @@ module "frontend_site" {
   bucket_name = var.frontend_bucket_name
 }
 
+output "cost_api_url" {
+  value = module.tenant_account.cost_api_url
+}
+
 output "tenant_account_id" {
   value = module.tenant_account.tenant_account_id
 }

--- a/saas/modules/tenant_account/main.tf
+++ b/saas/modules/tenant_account/main.tf
@@ -75,17 +75,17 @@ resource "aws_api_gateway_rest_api" "cost" {
 }
 
 resource "aws_api_gateway_resource" "cost" {
-  provider   = aws.tenant
+  provider    = aws.tenant
   rest_api_id = aws_api_gateway_rest_api.cost.id
   parent_id   = aws_api_gateway_rest_api.cost.root_resource_id
   path_part   = "cost"
 }
 
 resource "aws_api_gateway_method" "cost" {
-  provider   = aws.tenant
-  rest_api_id = aws_api_gateway_rest_api.cost.id
-  resource_id = aws_api_gateway_resource.cost.id
-  http_method = "GET"
+  provider      = aws.tenant
+  rest_api_id   = aws_api_gateway_rest_api.cost.id
+  resource_id   = aws_api_gateway_resource.cost.id
+  http_method   = "GET"
   authorization = "NONE"
 }
 
@@ -109,13 +109,13 @@ resource "aws_lambda_permission" "cost_apigw" {
 }
 
 resource "aws_api_gateway_deployment" "cost" {
-  provider   = aws.tenant
-  depends_on = [aws_api_gateway_integration.cost]
+  provider    = aws.tenant
+  depends_on  = [aws_api_gateway_integration.cost]
   rest_api_id = aws_api_gateway_rest_api.cost.id
 }
 
 resource "aws_api_gateway_stage" "cost" {
-  provider     = aws.tenant
+  provider      = aws.tenant
   deployment_id = aws_api_gateway_deployment.cost.id
   rest_api_id   = aws_api_gateway_rest_api.cost.id
   stage_name    = "prod"

--- a/saas/modules/tenant_account/main.tf
+++ b/saas/modules/tenant_account/main.tf
@@ -17,6 +17,114 @@ resource "aws_s3_bucket" "web" {
   bucket   = "minecraft-web-${var.tenant_id}"
 }
 
+# Lambda role for cost reporting
+resource "aws_iam_role" "cost_lambda" {
+  provider = aws.tenant
+  name     = "cost-report-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Action    = "sts:AssumeRole",
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "cost_explorer" {
+  provider = aws.tenant
+  name     = "cost-explorer"
+  role     = aws_iam_role.cost_lambda.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["ce:GetCostAndUsage"],
+      Resource = "*",
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cost_logs" {
+  provider   = aws.tenant
+  role       = aws_iam_role.cost_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "archive_file" "lambda_cost_report" {
+  provider    = aws.tenant
+  type        = "zip"
+  source_file = "${path.module}/../../lambda/cost_report.py"
+  output_path = "${path.module}/lambda_cost_report.zip"
+}
+
+resource "aws_lambda_function" "cost_report" {
+  provider         = aws.tenant
+  filename         = data.archive_file.lambda_cost_report.output_path
+  source_code_hash = data.archive_file.lambda_cost_report.output_base64sha256
+  function_name    = "cost-report"
+  role             = aws_iam_role.cost_lambda.arn
+  handler          = "cost_report.handler"
+  runtime          = "python3.11"
+  timeout          = 10
+}
+
+resource "aws_api_gateway_rest_api" "cost" {
+  provider = aws.tenant
+  name     = "cost-api"
+}
+
+resource "aws_api_gateway_resource" "cost" {
+  provider   = aws.tenant
+  rest_api_id = aws_api_gateway_rest_api.cost.id
+  parent_id   = aws_api_gateway_rest_api.cost.root_resource_id
+  path_part   = "cost"
+}
+
+resource "aws_api_gateway_method" "cost" {
+  provider   = aws.tenant
+  rest_api_id = aws_api_gateway_rest_api.cost.id
+  resource_id = aws_api_gateway_resource.cost.id
+  http_method = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "cost" {
+  provider                = aws.tenant
+  rest_api_id             = aws_api_gateway_rest_api.cost.id
+  resource_id             = aws_api_gateway_resource.cost.id
+  http_method             = aws_api_gateway_method.cost.http_method
+  integration_http_method = "GET"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.cost_report.invoke_arn
+}
+
+resource "aws_lambda_permission" "cost_apigw" {
+  provider      = aws.tenant
+  statement_id  = "AllowCostAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cost_report.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = aws_api_gateway_rest_api.cost.execution_arn
+}
+
+resource "aws_api_gateway_deployment" "cost" {
+  provider   = aws.tenant
+  depends_on = [aws_api_gateway_integration.cost]
+  rest_api_id = aws_api_gateway_rest_api.cost.id
+}
+
+resource "aws_api_gateway_stage" "cost" {
+  provider     = aws.tenant
+  deployment_id = aws_api_gateway_deployment.cost.id
+  rest_api_id   = aws_api_gateway_rest_api.cost.id
+  stage_name    = "prod"
+}
+
 output "tenant_account_id" {
   value = aws_organizations_account.this.id
+}
+
+output "cost_api_url" {
+  value = aws_api_gateway_stage.cost.invoke_url
 }

--- a/saas/modules/tenant_account/main.tf
+++ b/saas/modules/tenant_account/main.tf
@@ -52,7 +52,6 @@ resource "aws_iam_role_policy_attachment" "cost_logs" {
 }
 
 data "archive_file" "lambda_cost_report" {
-  provider    = aws.tenant
   type        = "zip"
   source_file = "${path.module}/../../lambda/cost_report.py"
   output_path = "${path.module}/lambda_cost_report.zip"

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -2,9 +2,10 @@
   <v-container>
     <v-row>
       <v-col>
-        <h2 class="text-h5 mb-4">Server Console</h2>
-        <div>{{ status }}</div>
-        <v-btn v-if="showStart" @click="start" class="mt-2">Start Server</v-btn>
+      <h2 class="text-h5 mb-4">Server Console</h2>
+      <div>{{ status }}</div>
+      <div class="mt-2">{{ cost }}</div>
+      <v-btn v-if="showStart" @click="start" class="mt-2">Start Server</v-btn>
       </v-col>
     </v-row>
   </v-container>
@@ -17,11 +18,13 @@ export default {
     return {
       status: 'Checking status...',
       showStart: false,
+      cost: 'Fetching cost...',
       interval: null,
     };
   },
   mounted() {
     this.fetchStatus();
+    this.fetchCost();
     this.interval = setInterval(this.fetchStatus, 30000);
   },
   beforeUnmount() {
@@ -59,6 +62,21 @@ export default {
         console.error(err);
         this.status = 'Could not start server.';
         this.showStart = true;
+      }
+    },
+    async fetchCost() {
+      try {
+        const res = await fetch('COST_API_URL', { headers: this.authHeader() });
+        const data = await res.json();
+        let text = `Monthly cost so far: $${data.total ?? 0}`;
+        if (data.breakdown) {
+          const parts = Object.entries(data.breakdown).map(([k, v]) => `${k}: $${v}`);
+          if (parts.length) text += ` ( ${parts.join(', ')} )`;
+        }
+        this.cost = text;
+      } catch (err) {
+        console.error(err);
+        this.cost = 'Error fetching cost.';
       }
     },
   },


### PR DESCRIPTION
## Summary
- add cost_report Lambda that queries AWS Cost Explorer
- expose cost_report function via API Gateway in each tenant account
- output cost_api_url through Terraform
- document new cost API

## Testing
- `python3 -m py_compile dev_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a93f34c08323895a169b88a9ff77