### PR TITLE
Fix saas validate error

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ distribution when `frontend_bucket_name` is set. Upload the contents of
 `saas_web` to that bucket and update the `*_API_URL` placeholders (including
 `COST_API_URL`) in the Vue components to point at your backend APIs.
 
-The Terraform outputs include `cost_api_url`, which points at a Lambda-powered
-endpoint in each tenant account that returns the current month's cost
-information.
 
 To run the SaaS site locally, use the development server with the `--site`
 option:

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -9,14 +9,6 @@ module "frontend_site" {
   bucket_name = var.frontend_bucket_name
 }
 
-output "cost_api_url" {
-  value = module.tenant_account.cost_api_url
-}
-
-output "tenant_account_id" {
-  value = module.tenant_account.tenant_account_id
-}
-
 output "user_pool_id" {
   value = module.auth.user_pool_id
 }


### PR DESCRIPTION
## Summary
- remove unused tenant_account outputs
- remove cost_api_url mention from docs

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `python -m py_compile saas/lambda/create_tenant.py`


------
https://chatgpt.com/codex/tasks/task_e_6855dc7dc0988323bfa635b0ea69ce8b