### PR TITLE
Fix caching with local dev server

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -15,6 +15,11 @@ MOCK_RESPONSES = {}
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        """Disable caching to ensure changes are always reflected."""
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
     def do_GET(self):
         resp = MOCK_RESPONSES.get(("GET", self.path))
         if resp:


### PR DESCRIPTION
## Summary
- disable caching in `dev_server.py`

## Testing
- `python -m py_compile dev_server.py`
- `html5validator --root saas_web`

------
https://chatgpt.com/codex/tasks/task_e_6855dd81ba28832380df90ac4aefbbd9