### PR TITLE
Secure frontend bucket via OAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ The `saas` directory contains Terraform configuration for creating tenant AWS ac
 ### SaaS Website
 
 The `saas_web` folder now contains the main SaaS site with signup, login and a
-simple management console. Terraform creates an S3 bucket and CloudFront
-distribution when `frontend_bucket_name` is set. Upload the contents of
-`saas_web` to that bucket and update the `*_API_URL` placeholders (including
-`COST_API_URL`) in the Vue components to point at your backend APIs.
+simple management console. Terraform creates a **private** S3 bucket and a
+CloudFront distribution using an Origin Access Identity when
+`frontend_bucket_name` is set. Upload the contents of `saas_web` to that bucket
+and update the `*_API_URL` placeholders (including `COST_API_URL`) in the Vue
+components to point at your backend APIs.
 
 
 To run the SaaS site locally, use the development server with the `--site`

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -6,10 +6,12 @@ provisioned when a user confirms their account.
 ## Deploying the Website
 
 1. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and set
-   `frontend_bucket_name` to the S3 bucket that will host the site.
+   `frontend_bucket_name` to the S3 bucket that will host the site. The bucket
+   remains private.
 2. Run `terraform -chdir=saas init` followed by `terraform -chdir=saas apply` from
    an AWS account with access to AWS Organizations. This creates the user pool,
-   tenant provisioning Lambda and S3 bucket/CloudFront distribution for the website.
+   tenant provisioning Lambda and a CloudFront distribution configured with an
+   Origin Access Identity for the bucket.
 3. Upload the contents of the `saas_web` directory to the created S3 bucket and
    update the `*_API_URL` placeholders (including `COST_API_URL`) inside the Vue
    components to point at your deployed APIs.


### PR DESCRIPTION
## Summary
- keep the SaaS frontend bucket private
- grant CloudFront access via an Origin Access Identity
- document the private bucket setup in README and saas_setup guide

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `python -m py_compile saas/lambda/create_tenant.py`


------
https://chatgpt.com/codex/tasks/task_e_68560cadb3088323829c2a1ed0a9b296