### PR TITLE
Switch server terraform to IPv6

### DIFF
--- a/docs/saas_layer.md
+++ b/docs/saas_layer.md
@@ -6,7 +6,7 @@ This document outlines a high level plan for supporting a multi‑tenant setup w
 - Use the `aws_organizations_account` resource from the AWS provider to create a new member account for each tenant.
 - All tenant accounts are placed in an organizational unit called `MinecraftTenants` for easier management.
 - After creation, Terraform can assume an IAM role in the new account (e.g. `OrganizationAccountAccessRole`) to deploy the server infrastructure.
-- Each tenant account receives its own VPC, EC2 instance and web bucket. An Elastic IP is allocated so the server address stays constant.
+- Each tenant account receives its own VPC, EC2 instance and web bucket. The instance relies on its static IPv6 address instead of an Elastic IP for a consistent endpoint.
 
 ## Authentication
 - Central authentication can be provided by Amazon Cognito in the management account.


### PR DESCRIPTION
## Summary
- switch the security group to allow IPv6 traffic
- drop Elastic IP usage and rely on EC2's IPv6 address
- update Lambda configuration and Terraform outputs for IPv6
- document IPv6 usage in SaaS architecture notes

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=terraform init`
- `terraform -chdir=terraform validate`
- `shellcheck terraform/user_data.sh`
- `python3 -m py_compile terraform/lambda/start_minecraft.py`


------
https://chatgpt.com/codex/tasks/task_e_68560e597ea08323b3bc282c62e53b60