### PR TITLE
Automate SaaS site upload via Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,19 @@ The `saas` directory contains Terraform configuration for creating tenant AWS ac
 The `saas_web` folder now contains the main SaaS site with signup, login and a
 simple management console. Terraform creates a **private** S3 bucket and a
 CloudFront distribution using an Origin Access Identity when
-`frontend_bucket_name` is set. Upload the contents of `saas_web` to that bucket
-and update the `*_API_URL` placeholders (including `COST_API_URL`) in the Vue
-components to point at your backend APIs.
+`frontend_bucket_name` is set. The website files are uploaded automatically
+during `terraform apply`. The `SIGNUP_API_URL` and `LOGIN_API_URL` placeholders
+in the Vue components are replaced with the Cognito endpoints you provide. The
+console obtains the cost, start and status endpoints from the tenant
+infrastructure after a user logs in, so those placeholders remain unchanged.
+
+Example `terraform.tfvars` entries:
+
+```hcl
+frontend_bucket_name = "example-landing-bucket"
+signup_api_url      = "https://example.com/signup"
+login_api_url       = "https://example.com/login"
+```
 
 
 To run the SaaS site locally, use the development server with the `--site`

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -12,9 +12,11 @@ provisioned when a user confirms their account.
    an AWS account with access to AWS Organizations. This creates the user pool,
    tenant provisioning Lambda and a CloudFront distribution configured with an
    Origin Access Identity for the bucket.
-3. Upload the contents of the `saas_web` directory to the created S3 bucket and
-   update the `*_API_URL` placeholders (including `COST_API_URL`) inside the Vue
-   components to point at your deployed APIs.
+3. `terraform -chdir=saas apply` will automatically upload the contents of
+   `saas_web` to the created S3 bucket. Only the `SIGNUP_API_URL` and
+   `LOGIN_API_URL` placeholders are replaced during apply. The console fetches
+   the cost, start and status endpoints from the tenant infrastructure after a
+   user logs in.
 
 ## Local Development
 
@@ -51,6 +53,5 @@ grants the user pool permission to invoke it.
 Each tenant account also includes a simple `cost_report` Lambda function that is
 exposed through an API Gateway endpoint. This function queries the AWS Cost
 Explorer API for the current month's charges and returns the total along with a
-breakdown by service. The endpoint URL is output as `cost_api_url` when the
-Terraform code is applied and should be used to replace the `COST_API_URL`
-placeholder in the Vue console component.
+breakdown by service. The console calls this endpoint after authenticating the
+user; no manual placeholder replacement is required.

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -9,6 +9,46 @@ module "frontend_site" {
   bucket_name = var.frontend_bucket_name
 }
 
+locals {
+  site_dir   = "${path.root}/../saas_web"
+  site_files = fileset(local.site_dir, "**")
+  placeholders = {
+    "SIGNUP_API_URL" = var.signup_api_url
+    "LOGIN_API_URL"  = var.login_api_url
+  }
+
+  processed_files = {
+    for f in local.site_files :
+    f => replace(
+      replace(
+        file("${local.site_dir}/${f}"),
+        "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
+      ),
+      "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
+    )
+  }
+
+  mime_types = {
+    html = "text/html"
+    js   = "application/javascript"
+    css  = "text/css"
+    vue  = "text/plain"
+  }
+}
+
+resource "aws_s3_object" "site" {
+  for_each = local.processed_files
+  bucket   = module.frontend_site.bucket_name
+  key      = each.key
+  content  = each.value
+  content_type = lookup(
+    local.mime_types,
+    lower(element(reverse(split(".", each.key)), 0)),
+    "text/plain",
+  )
+  etag = md5(each.value)
+}
+
 output "user_pool_id" {
   value = module.auth.user_pool_id
 }

--- a/saas/terraform.tfvars.example
+++ b/saas/terraform.tfvars.example
@@ -1,1 +1,3 @@
 frontend_bucket_name = "example-landing-bucket"
+signup_api_url      = "https://example.com/signup"
+login_api_url       = "https://example.com/login"

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -12,3 +12,13 @@ variable "frontend_bucket_name" {
   type    = string
   default = "minecraft-saas-frontend"
 }
+
+variable "signup_api_url" {
+  description = "Endpoint for user signup (Cognito)"
+  type        = string
+}
+
+variable "login_api_url" {
+  description = "Endpoint for user login (Cognito)"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- remove unused URL variables for tenant APIs
- keep signup/login URL substitution via Terraform
- note tenant endpoints are retrieved after Cognito login

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`
- `python3 -m py_compile saas/lambda/create_tenant.py`
- `python3 -m py_compile saas/lambda/cost_report.py`


------
https://chatgpt.com/codex/tasks/task_e_6856148f4b2c83239c9bc39bcf9785eb