### PR TITLE
Infer signup/login URLs from auth module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,15 @@ simple management console. Terraform creates a **private** S3 bucket and a
 CloudFront distribution using an Origin Access Identity when
 `frontend_bucket_name` is set. The website files are uploaded automatically
 during `terraform apply`. The `SIGNUP_API_URL` and `LOGIN_API_URL` placeholders
-in the Vue components are replaced with the Cognito endpoints you provide. The
-console obtains the cost, start and status endpoints from the tenant
-infrastructure after a user logs in, so those placeholders remain unchanged.
+in the Vue components are replaced with endpoints derived from the Cognito user
+pool so no additional variables are needed. The console obtains the cost, start
+and status endpoints from the tenant infrastructure after a user logs in, so
+those placeholders remain unchanged.
 
 Example `terraform.tfvars` entries:
 
 ```hcl
 frontend_bucket_name = "example-landing-bucket"
-signup_api_url      = "https://example.com/signup"
-login_api_url       = "https://example.com/login"
 ```
 
 

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -13,10 +13,10 @@ provisioned when a user confirms their account.
    tenant provisioning Lambda and a CloudFront distribution configured with an
    Origin Access Identity for the bucket.
 3. `terraform -chdir=saas apply` will automatically upload the contents of
-   `saas_web` to the created S3 bucket. Only the `SIGNUP_API_URL` and
-   `LOGIN_API_URL` placeholders are replaced during apply. The console fetches
-   the cost, start and status endpoints from the tenant infrastructure after a
-   user logs in.
+   `saas_web` to the created S3 bucket. The `SIGNUP_API_URL` and
+   `LOGIN_API_URL` placeholders are filled in using values derived from the
+   Cognito user pool. The console fetches the cost, start and status endpoints
+   from the tenant infrastructure after a user logs in.
 
 ## Local Development
 

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -13,8 +13,8 @@ locals {
   site_dir   = "${path.root}/../saas_web"
   site_files = fileset(local.site_dir, "**")
   placeholders = {
-    "SIGNUP_API_URL" = var.signup_api_url
-    "LOGIN_API_URL"  = var.login_api_url
+    "SIGNUP_API_URL" = module.auth.signup_api_url
+    "LOGIN_API_URL"  = module.auth.login_api_url
   }
 
   processed_files = {

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -81,3 +81,11 @@ output "user_pool_id" {
 output "user_pool_client_id" {
   value = aws_cognito_user_pool_client.this.id
 }
+
+output "signup_api_url" {
+  value = "${aws_cognito_user_pool.this.endpoint}/signup"
+}
+
+output "login_api_url" {
+  value = "${aws_cognito_user_pool.this.endpoint}/login"
+}

--- a/saas/terraform.tfvars.example
+++ b/saas/terraform.tfvars.example
@@ -1,3 +1,2 @@
 frontend_bucket_name = "example-landing-bucket"
-signup_api_url      = "https://example.com/signup"
-login_api_url       = "https://example.com/login"
+

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -13,12 +13,3 @@ variable "frontend_bucket_name" {
   default = "minecraft-saas-frontend"
 }
 
-variable "signup_api_url" {
-  description = "Endpoint for user signup (Cognito)"
-  type        = string
-}
-
-variable "login_api_url" {
-  description = "Endpoint for user login (Cognito)"
-  type        = string
-}


### PR DESCRIPTION
## Summary
- output signup and login URL endpoints from auth module
- reference these outputs when replacing placeholders
- simplify saas/terraform variables
- document auto-filled URLs in setup docs

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init -backend=false` *(fails: Failed to install provider)*
- `terraform -chdir=saas validate` *(fails: Missing required provider)*
- `python -m py_compile saas/lambda/create_tenant.py`


------
https://chatgpt.com/codex/tasks/task_e_68562b06e4e48323895275c88a88c041