### PR TITLE
Add CloudFront error pages

### DIFF
--- a/saas/modules/frontend_site/main.tf
+++ b/saas/modules/frontend_site/main.tf
@@ -46,6 +46,42 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
+  custom_error_response {
+    error_code         = 403
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 500
+    response_code      = 500
+    response_page_path = "/50x.html"
+  }
+
+  custom_error_response {
+    error_code         = 502
+    response_code      = 500
+    response_page_path = "/50x.html"
+  }
+
+  custom_error_response {
+    error_code         = 503
+    response_code      = 500
+    response_page_path = "/50x.html"
+  }
+
+  custom_error_response {
+    error_code         = 504
+    response_code      = 500
+    response_page_path = "/50x.html"
+  }
+
   price_class = "PriceClass_100"
   viewer_certificate {
     cloudfront_default_certificate = true

--- a/saas_web/404.html
+++ b/saas_web/404.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Page Not Found - Minecraft for All</title>
+  <link rel="stylesheet" href="vendor/vuetify.min.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: linear-gradient(135deg, #0d0d0d, #1a1a2e);
+      color: #ffffff;
+    }
+    #container {
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    a { color: #81d4fa; }
+    h1 { color: #b39ddb; }
+  </style>
+</head>
+<body>
+  <div id="container">
+    <h1>404 - Page Not Found</h1>
+    <p><a href="/">Return Home</a></p>
+  </div>
+</body>
+</html>

--- a/saas_web/50x.html
+++ b/saas_web/50x.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Error - Minecraft for All</title>
+  <link rel="stylesheet" href="vendor/vuetify.min.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: linear-gradient(135deg, #0d0d0d, #1a1a2e);
+      color: #ffffff;
+    }
+    #container {
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    a { color: #81d4fa; }
+    h1 { color: #b39ddb; }
+  </style>
+</head>
+<body>
+  <div id="container">
+    <h1>Oops! Something went wrong.</h1>
+    <p>Please try again later. <a href="/">Return Home</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple 404 and 50x HTML pages
- show 404 for 403/404 errors and a generic page for 5xx
- configure CloudFront distribution to use the new error pages

## Testing
- `html5validator --root saas_web`
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `python -m py_compile saas/lambda/create_tenant.py`


------
https://chatgpt.com/codex/tasks/task_e_68562fdbca008323bb908535b28730b4