### PR TITLE
Signup flow with email verification

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
     MOCK_RESPONSES.update(
         {
             ("POST", "/SIGNUP_API_URL"): (200, None),
+            ("POST", "/CONFIRM_API_URL"): (200, None),
             ("POST", "/LOGIN_API_URL"): (200, {"token": "dummy"}),
             ("GET", "/STATUS_API_URL"): (200, {"state": "offline"}),
             ("POST", "/START_API_URL"): (200, None),

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -15,16 +15,20 @@ locals {
   placeholders = {
     "SIGNUP_API_URL" = module.auth.signup_api_url
     "LOGIN_API_URL"  = module.auth.login_api_url
+    "CONFIRM_API_URL" = module.auth.confirm_api_url
   }
 
   processed_files = {
     for f in local.site_files :
     f => replace(
       replace(
-        file("${local.site_dir}/${f}"),
-        "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
+        replace(
+          file("${local.site_dir}/${f}"),
+          "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
+        ),
+        "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
       ),
-      "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
+      "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
     )
   }
 

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -89,3 +89,7 @@ output "signup_api_url" {
 output "login_api_url" {
   value = "${aws_cognito_user_pool.this.endpoint}/login"
 }
+
+output "confirm_api_url" {
+  value = "${aws_cognito_user_pool.this.endpoint}/confirm"
+}

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -9,6 +9,10 @@
           <v-btn type="submit" color="deep-purple-accent-2" class="mt-2">Login</v-btn>
         </v-form>
         <div class="mt-2">{{ message }}</div>
+        <div class="mt-2">
+          Don't have an account?
+          <router-link to="/start">Sign up here</router-link>
+        </div>
       </v-col>
     </v-row>
   </v-container>

--- a/saas_web/components/Start.vue
+++ b/saas_web/components/Start.vue
@@ -5,6 +5,8 @@
         <h2 class="text-h5 mb-4">Start your server</h2>
         <v-form @submit.prevent="submit">
           <v-text-field v-model="email" label="Email" type="email" required></v-text-field>
+          <v-text-field v-model="password" label="Password" type="password" required></v-text-field>
+          <v-text-field v-model="confirm" label="Confirm Password" type="password" required></v-text-field>
           <v-select v-model="players" :items="playerOptions" label="Players" required></v-select>
           <v-checkbox v-model="pregen" label="Pregenerate world"></v-checkbox>
           <v-btn type="submit" color="deep-purple-accent-2" class="mt-2">Launch</v-btn>
@@ -23,6 +25,8 @@ export default {
       email: '',
       players: 4,
       pregen: true,
+      password: '',
+      confirm: '',
       message: '',
       playerOptions: Array.from({ length: 20 }, (_, i) => i + 1),
     };
@@ -30,18 +34,24 @@ export default {
   methods: {
     async submit() {
       this.message = 'Submitting...';
+      if (this.password !== this.confirm) {
+        this.message = 'Passwords do not match.';
+        return;
+      }
       try {
         const res = await fetch('SIGNUP_API_URL', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             email: this.email,
+            password: this.password,
             players: this.players,
             pregen: this.pregen,
           }),
         });
         if (!res.ok) throw new Error('Failed');
-        this.message = 'Check your email for server details.';
+        this.message = 'Check your email for the verification code.';
+        this.$router.push({ path: '/verify', query: { email: this.email } });
       } catch (err) {
         console.error(err);
         this.message = 'Request failed. Please try again later.';

--- a/saas_web/components/Verify.vue
+++ b/saas_web/components/Verify.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="6" lg="4">
+        <h2 class="text-h5 mb-4">Verify Email</h2>
+        <v-form @submit.prevent="submit">
+          <v-text-field v-model="code" label="Verification Code" required></v-text-field>
+          <v-btn type="submit" color="deep-purple-accent-2" class="mt-2">Verify</v-btn>
+        </v-form>
+        <div class="mt-2">{{ message }}</div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'Verify',
+  data() {
+    return {
+      email: '',
+      code: '',
+      message: '',
+    };
+  },
+  created() {
+    this.email = this.$route.query.email || '';
+  },
+  methods: {
+    async submit() {
+      this.message = 'Verifying...';
+      try {
+        const res = await fetch('CONFIRM_API_URL', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: this.email, code: this.code }),
+        });
+        if (!res.ok) throw new Error('Failed');
+        this.message = 'Email verified! You can now log in.';
+        this.$router.push('/login');
+      } catch (err) {
+        console.error(err);
+        this.message = 'Verification failed. Please try again.';
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -29,6 +29,7 @@ const options = {
       { path: '/login', component: () => window['vue3-sfc-loader'].loadModule('./components/Login.vue', options) },
       { path: '/console', component: () => window['vue3-sfc-loader'].loadModule('./components/Console.vue', options) },
       { path: '/start', component: () => window['vue3-sfc-loader'].loadModule('./components/Start.vue', options) },
+      { path: '/verify', component: () => window['vue3-sfc-loader'].loadModule('./components/Verify.vue', options) },
       { path: '/:pathMatch(.*)*', component: () => window['vue3-sfc-loader'].loadModule('./components/NotFound.vue', options) },
     ],
   });


### PR DESCRIPTION
## Summary
- include confirm API output for Cognito
- replace new placeholders in SaaS site assets
- mock email verification endpoint in the dev server
- link from login page to signup/start
- collect password info on Start page and redirect to OTP page
- add Verify component and route

## Testing
- `pip install html5validator`
- `html5validator --root saas_web`
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `python -m py_compile saas/lambda/create_tenant.py`


------
https://chatgpt.com/codex/tasks/task_e_685842abae20832394bf589fb413cd7f