### PR TITLE
Fix CloudFront SPA routing

### DIFF
--- a/saas/modules/frontend_site/spa-redirect.js
+++ b/saas/modules/frontend_site/spa-redirect.js
@@ -1,15 +1,12 @@
 function handler(event) {
-    var request = event.request;
-    var uri = request.uri;
-  
-    if (!uri.includes('.') && !uri.endsWith('/')) {
-      request.uri += '/';
-    }
-  
-    if (request.uri.endsWith('/')) {
-      request.uri += 'index.html';
-    }
-  
-    return request;
+  var request = event.request;
+  var uri = request.uri;
+
+  // If the request is not for a specific file, serve the SPA entry point.
+  if (!uri.includes('.')) {
+    request.uri = '/index.html';
   }
+
+  return request;
+}
   


### PR DESCRIPTION
## Summary
- fix the `spa-redirect.js` CloudFront function to send all non-file paths to `/index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858c3d1a4888323b4e8bbc6ffe7a364