### PR TITLE
Fix Cognito signup URL scheme

### DIFF
--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -102,13 +102,13 @@ output "user_pool_client_id" {
 }
 
 output "signup_api_url" {
-  value = "${aws_cognito_user_pool.this.endpoint}/signup"
+  value = "https://${aws_cognito_user_pool.this.endpoint}/signup"
 }
 
 output "login_api_url" {
-  value = "${aws_cognito_user_pool.this.endpoint}/login"
+  value = "https://${aws_cognito_user_pool.this.endpoint}/login"
 }
 
 output "confirm_api_url" {
-  value = "${aws_cognito_user_pool.this.endpoint}/confirm"
+  value = "https://${aws_cognito_user_pool.this.endpoint}/confirm"
 }


### PR DESCRIPTION
## Summary
- include the `https://` scheme when constructing Cognito API URLs

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858c42efa108323a874c198395f2f56