### PR TITLE
Update to single Cognito API attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ python3 dev_server.py
 
 This serves the files from `saas_web` and mocks the various API endpoints so the
 forms and console can be tested without deploying any backend, including a dummy
-`/COST_API_URL` used on the console page.
+`/MC_API/cost` used on the console page.

--- a/dev_server.py
+++ b/dev_server.py
@@ -51,9 +51,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 if __name__ == "__main__":
     dummy_token = (
         "eyJhbGciOiAibm9uZSJ9."
-        "eyJjdXN0b206c3RhcnRfdXJsIjogIi9TVEFSVF9BUElfVVJMIiwg"
-        "ImN1c3RvbTpzdGF0dXNfdXJsIjogIi9TVEFUVVNfQVBJX1VSTCIsICJj"
-        "dXN0b206Y29zdF91cmwiOiAiL0NPU1RfQVBJX1VSTCJ9."
+        "eyJjdXN0b206bWNfYXBpX3VybCI6ICIvTUNfQVBJIn0=."
     )
 
     MOCK_RESPONSES.update(
@@ -61,9 +59,9 @@ if __name__ == "__main__":
             ("POST", "/SIGNUP_API_URL"): (200, None),
             ("POST", "/CONFIRM_API_URL"): (200, None),
             ("POST", "/LOGIN_API_URL"): (200, {"token": dummy_token}),
-            ("GET", "/STATUS_API_URL"): (200, {"state": "offline"}),
-            ("POST", "/START_API_URL"): (200, None),
-            ("GET", "/COST_API_URL"): (200, {"total": 0}),
+            ("GET", "/MC_API/status"): (200, {"state": "offline"}),
+            ("POST", "/MC_API/start"): (200, None),
+            ("GET", "/MC_API/cost"): (200, {"total": 0}),
         }
     )
 

--- a/saas/lambda/create_tenant.py
+++ b/saas/lambda/create_tenant.py
@@ -92,12 +92,10 @@ def handler(event, context):
             UserPoolId=user_pool_id,
             Username=username,
             UserAttributes=[
-                {"Name": "custom:start_url", "Value": ""},
-                {"Name": "custom:status_url", "Value": ""},
-                {"Name": "custom:cost_url", "Value": ""},
+                {"Name": "custom:mc_api_url", "Value": ""},
             ],
         )
-        logger.info("Initialized custom attributes for %s", username)
+        logger.info("Initialized custom attribute for %s", username)
     except Exception:
         logger.exception("Failed to set default attributes for %s", username)
 

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -13,10 +13,10 @@ locals {
   site_dir   = "${path.root}/../saas_web"
   site_files = fileset(local.site_dir, "**")
   placeholders = {
-    "SIGNUP_API_URL"  = module.auth.signup_api_url
-    "LOGIN_API_URL"   = module.auth.login_api_url
-    "CONFIRM_API_URL" = module.auth.confirm_api_url
-    "USER_POOL_ID" = module.auth.user_pool_id
+    "SIGNUP_API_URL"      = module.auth.signup_api_url
+    "LOGIN_API_URL"       = module.auth.login_api_url
+    "CONFIRM_API_URL"     = module.auth.confirm_api_url
+    "USER_POOL_ID"        = module.auth.user_pool_id
     "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id
   }
 

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -5,22 +5,10 @@ resource "aws_cognito_user_pool" "this" {
     post_confirmation = aws_lambda_function.create_tenant.arn
   }
 
-  # Custom attributes store per-tenant API endpoints
+  # Custom attribute for the tenant API base URL
   schema {
     attribute_data_type = "String"
-    name                = "start_url"
-    mutable             = true
-  }
-
-  schema {
-    attribute_data_type = "String"
-    name                = "status_url"
-    mutable             = true
-  }
-
-  schema {
-    attribute_data_type = "String"
-    name                = "cost_url"
+    name                = "mc_api_url"
     mutable             = true
   }
 }

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -20,14 +20,7 @@ export default {
       showStart: false,
       cost: 'Fetching cost...',
       interval: null,
-      urls: (() => {
-        try {
-          return JSON.parse(localStorage.getItem('urls') || '{}');
-        } catch (err) {
-          console.error('Error parsing urls from localStorage:', err);
-          return {};
-        }
-      })(),
+      api_url: localStorage.getItem('api_url') || '',
     };
   },
   mounted() {
@@ -43,12 +36,12 @@ export default {
       const token = localStorage.getItem('token');
       return token ? { Authorization: `Bearer ${token}` } : {};
     },
-    endpoint(name) {
-      return this.urls[name] || name;
+    endpoint(path) {
+      return this.api_url ? `${this.api_url}/${path}` : path;
     },
     async fetchStatus() {
       try {
-        const res = await fetch(this.endpoint('status_url'), { headers: this.authHeader() });
+        const res = await fetch(this.endpoint('status'), { headers: this.authHeader() });
         const data = await res.json();
         if (data.state === 'running') {
           const players = data.players ?? 0;
@@ -67,7 +60,7 @@ export default {
       this.showStart = false;
       this.status = 'Starting...';
       try {
-        const res = await fetch(this.endpoint('start_url'), { method: 'POST', headers: this.authHeader() });
+        const res = await fetch(this.endpoint('start'), { method: 'POST', headers: this.authHeader() });
         if (!res.ok) throw new Error('Failed');
       } catch (err) {
         console.error(err);
@@ -77,7 +70,7 @@ export default {
     },
     async fetchCost() {
       try {
-        const res = await fetch(this.endpoint('cost_url'), { headers: this.authHeader() });
+        const res = await fetch(this.endpoint('cost'), { headers: this.authHeader() });
         const data = await res.json();
         let text = `Monthly cost so far: $${data.total ?? 0}`;
         if (data.breakdown) {

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -37,7 +37,8 @@ export default {
       return token ? { Authorization: `Bearer ${token}` } : {};
     },
     endpoint(path) {
-      return this.api_url ? `${this.api_url}/${path}` : path;
+      const normalizedApiUrl = this.api_url.replace(/\/+$/, ''); // Remove trailing slashes
+      return normalizedApiUrl ? `${normalizedApiUrl}/${path}` : path;
     },
     async fetchStatus() {
       try {

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -56,12 +56,8 @@ export default {
         localStorage.setItem('token', token);
         try {
           const payload = VueJwtDecode.decode(token);
-          const urls = {
-            start_url: payload['custom:start_url'] || '',
-            status_url: payload['custom:status_url'] || '',
-            cost_url: payload['custom:cost_url'] || '',
-          };
-          localStorage.setItem('urls', JSON.stringify(urls));
+          const apiUrl = payload['custom:mc_api_url'] || '';
+          localStorage.setItem('api_url', apiUrl);
         } catch (e) {
           console.error('Failed to parse token', e);
         }


### PR DESCRIPTION
## Summary
- simplify Cognito custom attributes to just `mc_api_url`
- update tenant creation Lambda accordingly
- adapt console and login pages to new attribute
- tweak dev server mock endpoints
- minor README note update

## Testing
- `terraform -chdir=saas fmt -check -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `python -m py_compile saas/lambda/create_tenant.py`
- `html5validator --root saas_web`


------
https://chatgpt.com/codex/tasks/task_e_685a05ab63048323a368476276f1be85