### PR TITLE
Fix Cognito schema update errors

### DIFF
--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -11,6 +11,14 @@ resource "aws_cognito_user_pool" "this" {
     name                = "mc_api_url"
     mutable             = true
   }
+
+  # Once a schema attribute is created it cannot be modified in place.
+  # Terraform occasionally tries to update this block when provider
+  # defaults change, which results in a failure.  Ignore any changes
+  # so that the pool remains intact.
+  lifecycle {
+    ignore_changes = [schema]
+  }
 }
 
 resource "aws_cognito_user_pool_client" "this" {


### PR DESCRIPTION
## Summary
- ensure user pool schema isn't modified after creation by Terraform

## Testing
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_685a0fcc89a483238c256463416a23b7