### PR TITLE
Fix runtime JS errors

### DIFF
--- a/saas_web/cognito.js
+++ b/saas_web/cognito.js
@@ -4,3 +4,7 @@ export const poolData = {
 };
 
 export const userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
+
+if (typeof window !== 'undefined') {
+  window.userPool = userPool;
+}

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -20,7 +20,6 @@
 
 <script>
 import VueJwtDecode from 'vue-jwt-decode'
-import { userPool } from '../cognito.js';
 
 export default {
   name: 'Login',

--- a/saas_web/components/Start.vue
+++ b/saas_web/components/Start.vue
@@ -18,7 +18,6 @@
 </template>
 
 <script>
-import { userPool } from '../cognito.js';
 export default {
   name: 'Start',
   data() {

--- a/saas_web/components/Verify.vue
+++ b/saas_web/components/Verify.vue
@@ -14,7 +14,6 @@
 </template>
 
 <script>
-import { userPool } from '../cognito.js';
 export default {
   name: 'Verify',
   data() {

--- a/saas_web/index.html
+++ b/saas_web/index.html
@@ -28,6 +28,8 @@
   <script src="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vue3-sfc-loader@0.9.5/dist/vue3-sfc-loader.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/amazon-cognito-identity-js@6.2.2/dist/amazon-cognito-identity.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue-jwt-decode@0.1.0/dist/lib/vue-jwt-decode.min.js"></script>
+  <script type="module" src="./cognito.js"></script>
   <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -1,5 +1,9 @@
 const options = {
-  moduleCache: { vue: Vue, 'vue-router': VueRouter },
+  moduleCache: {
+    vue: Vue,
+    'vue-router': VueRouter,
+    'vue-jwt-decode': window['vue-jwt-decode'],
+  },
   async getFile(url) {
     const res = await fetch(url);
     if (!res.ok) throw Object.assign(new Error(res.statusText + ' ' + url), { res });


### PR DESCRIPTION
## Summary
- load vue-jwt-decode via CDN and expose it to the SFC loader
- keep Cognito userPool global via helper script
- parse JWT with vue-jwt-decode again

## Testing
- `python3 -m py_compile saas/lambda/*.py`
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a117d203c8323ab3ae46b3e863b66