### PR TITLE
Make SaaS CodeBuild tenant-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A design proposal for running each tenant in a separate AWS account is available
 
 Step-by-step instructions for deploying the SaaS site and tenant provisioning Lambda are provided in [docs/saas_setup.md](docs/saas_setup.md).
 
-The same Terraform layer can also provision an optional CodeBuild project in each tenant account for running the server configuration.
+The same Terraform layer also provisions a CodeBuild project in the management account. The build assumes a role in the target tenant account when started, so no tenant information is needed until execution time.
 The `saas` directory contains Terraform configuration for creating tenant AWS accounts and a Cognito user pool for authentication. Copy `saas/terraform.tfvars.example` to `saas/terraform.tfvars` and update the values. Run `terraform -chdir=saas init` once to download the providers and modules, then you can use `terraform -chdir=saas validate` or `terraform -chdir=saas apply` from a management account that has access to AWS Organizations.
 
 ### SaaS Website

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -1,10 +1,3 @@
-provider "aws" {
-  alias  = "tenant"
-  region = var.region
-  assume_role {
-    role_arn = "arn:aws:iam::${var.tenant_account_id}:role/OrganizationAccountAccessRole"
-  }
-}
 
 module "auth" {
   source         = "./modules/auth"
@@ -70,10 +63,8 @@ resource "aws_s3_object" "site" {
 }
 module "tenant_codebuild" {
   source         = "./modules/codebuild_provisioner"
-  providers      = { aws = aws.tenant }
   project_name   = "tenant-terraform"
   repository_url = var.repository_url
-  count          = var.tenant_account_id == "" ? 0 : 1
 }
 
 

--- a/saas/modules/codebuild_provisioner/buildspec.yml
+++ b/saas/modules/codebuild_provisioner/buildspec.yml
@@ -8,8 +8,18 @@ phases:
       - curl -Lo terraform.zip https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip
       - unzip terraform.zip
       - mv terraform /usr/local/bin/terraform
+      - yum install -y jq
   build:
     commands:
+      - |
+          if [ -z "$TENANT_ACCOUNT_ID" ]; then
+            echo "TENANT_ACCOUNT_ID not set"
+            exit 1
+          fi
+      - creds=$(aws sts assume-role --role-arn arn:aws:iam::${TENANT_ACCOUNT_ID}:role/OrganizationAccountAccessRole --role-session-name codebuild-tenant)
+      - export AWS_ACCESS_KEY_ID=$(echo $creds | jq -r .Credentials.AccessKeyId)
+      - export AWS_SECRET_ACCESS_KEY=$(echo $creds | jq -r .Credentials.SecretAccessKey)
+      - export AWS_SESSION_TOKEN=$(echo $creds | jq -r .Credentials.SessionToken)
       - git clone $REPOSITORY_URL repo
       - cd repo/terraform
       - terraform init -input=false

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -25,12 +25,3 @@ variable "repository_url" {
   type        = string
 }
 
-variable "tenant_account_id" {
-  description = "ID of the tenant AWS account for provisioning"
-  type        = string
-  default     = null
-  validation {
-    condition     = var.tenant_account_id != null && length(var.tenant_account_id) > 0
-    error_message = "The tenant_account_id must be provided and cannot be empty."
-  }
-}


### PR DESCRIPTION
## Summary
- keep SaaS build pipeline independent of any tenant
- assume the tenant role at runtime via `TENANT_ACCOUNT_ID`
- document how to trigger the pipeline

## Testing
- `terraform fmt -recursive saas`
- `html5validator --root saas_web`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`


------
https://chatgpt.com/codex/tasks/task_e_685a19251ca8832385047c25e68195e0