### PR TITLE
Add resend verification and relax password policy

### DIFF
--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -5,6 +5,16 @@ resource "aws_cognito_user_pool" "this" {
     post_confirmation = aws_lambda_function.create_tenant.arn
   }
 
+  auto_verified_attributes = ["email"]
+
+  password_policy {
+    minimum_length    = 8
+    require_lowercase = true
+    require_uppercase = false
+    require_numbers   = true
+    require_symbols   = false
+  }
+
   # Custom attribute for the tenant API base URL
   schema {
     attribute_data_type = "String"

--- a/saas_web/components/Start.vue
+++ b/saas_web/components/Start.vue
@@ -39,17 +39,11 @@ export default {
       if (this.password.length < 8) {
         return 'be at least 8 characters long';
       }
-      if (!/[a-z]/.test(this.password)) {
-        return 'include a lowercase letter';
-      }
-      if (!/[A-Z]/.test(this.password)) {
-        return 'include an uppercase letter';
+      if (!/[A-Za-z]/.test(this.password)) {
+        return 'include at least one letter';
       }
       if (!/[0-9]/.test(this.password)) {
-        return 'include a number';
-      }
-      if (!/[!@#$%^&*(),.?":{}|<>]/.test(this.password)) {
-        return 'include a special character';
+        return 'include at least one number';
       }
       return '';
     },

--- a/saas_web/components/Verify.vue
+++ b/saas_web/components/Verify.vue
@@ -7,6 +7,12 @@
           <v-text-field v-model="code" label="Verification Code" required></v-text-field>
           <v-btn type="submit" color="deep-purple-accent-2" class="mt-2">Verify</v-btn>
         </v-form>
+        <v-btn
+          color="deep-purple-accent-2"
+          class="mt-2"
+          variant="outlined"
+          @click="resend"
+        >Resend Code</v-btn>
         <div class="mt-2">{{ message }}</div>
       </v-col>
     </v-row>
@@ -49,6 +55,27 @@ export default {
       } catch (err) {
         console.error(err);
         this.message = 'Verification failed. Please try again.';
+      }
+    },
+    async resend() {
+      this.message = 'Resending code...';
+      try {
+        const cognitoUser = new AmazonCognitoIdentity.CognitoUser({
+          Username: this.email,
+          Pool: userPool,
+        });
+
+        await new Promise((resolve, reject) => {
+          cognitoUser.resendConfirmationCode((err, result) => {
+            if (err) return reject(err);
+            return resolve(result);
+          });
+        });
+
+        this.message = 'Verification code resent.';
+      } catch (err) {
+        console.error(err);
+        this.message = 'Failed to resend code. Please try again later.';
       }
     },
   },


### PR DESCRIPTION
## Summary
- enable Cognito email auto verification and set simpler password policy
- relax frontend password checks
- add "Resend Code" option to verification page

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `terraform -chdir=saas init -input=false`
- `terraform -chdir=saas validate`


------
https://chatgpt.com/codex/tasks/task_e_685ac7543d908323a9017c7d809d9dab