### PR TITLE
Improve verification email branding

### DIFF
--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -15,6 +15,16 @@ resource "aws_cognito_user_pool" "this" {
     require_symbols   = false
   }
 
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_subject        = "Welcome to Minecraft For All"
+    email_message        = <<EOF
+Thank you for joining Minecraft For All!
+Your verification code is {####}.
+Happy crafting!
+EOF
+  }
+
   # Custom attribute for the tenant API base URL
   schema {
     attribute_data_type = "String"


### PR DESCRIPTION
## Summary
- update Cognito user pool to send a branded verification email

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`


------
https://chatgpt.com/codex/tasks/task_e_685ad4745048832394a27db84e26cb61