### PR TITLE
Add reusable cost calculator component

### DIFF
--- a/saas_web/components/CostCalculator.vue
+++ b/saas_web/components/CostCalculator.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <h2 class="text-h5 mb-2"><i class="fas fa-calculator mr-2"></i>Projected Cost Calculator</h2>
+    <v-form>
+      <v-switch v-model="statsMode" label="Stats mode" class="mb-4"></v-switch>
+      <div v-if="!statsMode">
+        <v-text-field v-model.number="players" label="Expected number of players" type="number"></v-text-field>
+        <v-text-field v-model.number="playtime" label="Expected playtime per week (hrs)" type="number"></v-text-field>
+        <v-select v-model="mod" :items="mods" label="Mod options"></v-select>
+        <v-expansion-panels multiple>
+          <v-expansion-panel>
+            <v-expansion-panel-title>Advanced</v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <v-text-field v-model.number="worldSize" label="Expected world size (GB)" type="number"></v-text-field>
+              <v-select v-model="playStyle" :items="playStyles" label="Play style"></v-select>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </div>
+      <div v-else>
+        <v-text-field v-model.number="vcpus" label="vCPUs" type="number"></v-text-field>
+        <v-text-field v-model.number="memory" label="Memory (GB)" type="number"></v-text-field>
+        <v-text-field v-model.number="uptime" label="Uptime per week (hrs)" type="number"></v-text-field>
+        <v-text-field v-model.number="statsWorldSize" label="World size (GB)" type="number"></v-text-field>
+      </div>
+      <div class="mt-4">Estimated monthly cost: ${{ projectedCost }}</div>
+    </v-form>
+  </div>
+</template>
+
+<script>
+import {
+  baseRates,
+  styleMultipliers,
+  hoursPerWeekToMonth,
+  storageRate,
+  dataTransferPerPlayerPerHour,
+  freeDataTransferGb,
+  dataTransferRate,
+  vcpuRate,
+  memoryRate,
+} from '../pricingData.js';
+
+export default {
+  name: 'CostCalculator',
+  data() {
+    return {
+      statsMode: false,
+      players: 4,
+      playtime: 10,
+      mod: 'Vanilla',
+      mods: Object.keys(baseRates),
+      worldSize: 1,
+      playStyle: 'Adventure and build bases together',
+      playStyles: Object.keys(styleMultipliers),
+      vcpus: 2,
+      memory: 4,
+      uptime: 10,
+      statsWorldSize: 1,
+    };
+  },
+  computed: {
+    projectedCost() {
+      if (!this.statsMode) {
+        const rate = baseRates[this.mod] ?? baseRates['Vanilla'];
+        const styleMult = styleMultipliers[this.playStyle] ?? 1;
+        const hoursPerMonth = this.playtime * hoursPerWeekToMonth;
+        const server = rate * styleMult * hoursPerMonth;
+        const dataOut = this.players * this.playtime * dataTransferPerPlayerPerHour * hoursPerWeekToMonth;
+        const dataCost = Math.max(0, dataOut - freeDataTransferGb) * dataTransferRate;
+        const storage = this.worldSize * storageRate;
+        return (server + dataCost + storage).toFixed(2);
+      }
+      const hoursPerMonth = this.uptime * hoursPerWeekToMonth;
+      const rate = this.vcpus * vcpuRate + this.memory * memoryRate;
+      const server = rate * hoursPerMonth;
+      const storage = this.statsWorldSize * storageRate;
+      return (server + storage).toFixed(2);
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>
+

--- a/saas_web/components/Home.vue
+++ b/saas_web/components/Home.vue
@@ -15,31 +15,7 @@
       </v-row>
       <v-row>
         <v-col cols="12" md="6" lg="5">
-          <h2 class="text-h5 mb-2"><i class="fas fa-calculator mr-2"></i>Projected Cost Calculator</h2>
-          <v-form>
-            <v-switch v-model="statsMode" label="Stats mode" class="mb-4"></v-switch>
-            <div v-if="!statsMode">
-              <v-text-field v-model.number="players" label="Expected number of players" type="number"></v-text-field>
-              <v-text-field v-model.number="playtime" label="Expected playtime per week (hrs)" type="number"></v-text-field>
-              <v-select v-model="mod" :items="mods" label="Mod options"></v-select>
-              <v-expansion-panels multiple>
-                <v-expansion-panel>
-                  <v-expansion-panel-title>Advanced</v-expansion-panel-title>
-                  <v-expansion-panel-text>
-                    <v-text-field v-model.number="worldSize" label="Expected world size (GB)" type="number"></v-text-field>
-                    <v-select v-model="playStyle" :items="playStyles" label="Play style"></v-select>
-                  </v-expansion-panel-text>
-                </v-expansion-panel>
-              </v-expansion-panels>
-            </div>
-            <div v-else>
-              <v-text-field v-model.number="vcpus" label="vCPUs" type="number"></v-text-field>
-              <v-text-field v-model.number="memory" label="Memory (GB)" type="number"></v-text-field>
-              <v-text-field v-model.number="uptime" label="Uptime per week (hrs)" type="number"></v-text-field>
-              <v-text-field v-model.number="statsWorldSize" label="World size (GB)" type="number"></v-text-field>
-            </div>
-            <div class="mt-4">Estimated monthly cost: ${{ projectedCost }}</div>
-          </v-form>
+          <CostCalculator />
         </v-col>
       </v-row>
     </v-container>
@@ -47,56 +23,9 @@
 </template>
 
 <script>
+import CostCalculator from './CostCalculator.vue';
 export default {
   name: 'Home',
-  data() {
-    return {
-      statsMode: false,
-      players: 4,
-      playtime: 10,
-      mod: 'Vanilla',
-      mods: ['Vanilla', 'Vanilla-ish PaperMC', 'PaperMC (heavier mods)'],
-      worldSize: 1,
-      playStyle: 'Adventure and build bases together',
-      playStyles: [
-        'Adventure and build bases together',
-        'We like to make a lot of farms',
-        "It's really best to have a villager breeder per chunk...",
-      ],
-      vcpus: 2,
-      memory: 4,
-      uptime: 10,
-      statsWorldSize: 1,
-    };
-  },
-  computed: {
-    projectedCost() {
-      if (!this.statsMode) {
-        const rateMap = {
-          Vanilla: 0.0168,
-          'Vanilla-ish PaperMC': 0.0336,
-          'PaperMC (heavier mods)': 0.0832,
-        };
-        const styleMap = {
-          'Adventure and build bases together': 1,
-          'We like to make a lot of farms': 1.5,
-          "It's really best to have a villager breeder per chunk...": 2,
-        };
-        const rate = rateMap[this.mod] ?? 0.0168;
-        const styleMult = styleMap[this.playStyle] ?? 1;
-        const hoursPerMonth = this.playtime * 4.3;
-        const server = rate * styleMult * hoursPerMonth;
-        const dataOut = this.players * this.playtime * 0.1 * 4.3;
-        const dataCost = Math.max(0, dataOut - 1) * 0.09;
-        const storage = this.worldSize * 0.08;
-        return (server + dataCost + storage).toFixed(2);
-      }
-      const hoursPerMonth = this.uptime * 4.3;
-      const rate = this.vcpus * 0.008 + this.memory * 0.004;
-      const server = rate * hoursPerMonth;
-      const storage = this.statsWorldSize * 0.08;
-      return (server + storage).toFixed(2);
-    },
-  },
+  components: { CostCalculator },
 };
 </script>

--- a/saas_web/components/Pricing.vue
+++ b/saas_web/components/Pricing.vue
@@ -20,12 +20,20 @@
         <p>We've developed a number of solutions to keep cost down for you. When there are no players on your server for a certain amount of time the server will shut down automatically (but don't worry, you can turn it back on quickly and easily). We also automate your server data's lifecycle, essentially meaning it's available when you want it but also cheaper than standard.</p>
       </v-col>
     </v-row>
+
+    <v-row>
+      <v-col cols="12" md="6" lg="5">
+        <CostCalculator />
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
 <script>
+import CostCalculator from './CostCalculator.vue';
 export default {
   name: 'Pricing',
+  components: { CostCalculator },
 };
 </script>
 

--- a/saas_web/pricingData.js
+++ b/saas_web/pricingData.js
@@ -1,0 +1,20 @@
+export const baseRates = {
+  Vanilla: 0.0168,
+  'Vanilla-ish PaperMC': 0.0336,
+  'PaperMC (heavier mods)': 0.0832,
+};
+
+export const styleMultipliers = {
+  'Adventure and build bases together': 1,
+  'We like to make a lot of farms': 1.5,
+  "It's really best to have a villager breeder per chunk...": 2,
+};
+
+export const hoursPerWeekToMonth = 4.3;
+export const storageRate = 0.08;
+export const dataTransferPerPlayerPerHour = 0.1;
+export const freeDataTransferGb = 1;
+export const dataTransferRate = 0.09;
+
+export const vcpuRate = 0.008;
+export const memoryRate = 0.004;


### PR DESCRIPTION
## Summary
- pull out price calculator from Home.vue
- use CostCalculator on Home and Pricing pages
- store pricing constants in a new module

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py` (served content without errors)

------
https://chatgpt.com/codex/tasks/task_e_685ade453b30832381d75413bddbef2e