### PR TITLE
Fix StepIndicator progress UI

### DIFF
--- a/saas_web/components/start/StepIndicator.vue
+++ b/saas_web/components/start/StepIndicator.vue
@@ -1,12 +1,21 @@
 <template>
-  <div class="d-flex justify-center mb-4">
+  <div class="d-flex justify-center mb-4 align-center">
     <div
       v-for="n in total"
       :key="n"
-      class="step-circle mx-1"
-      :class="{ done: n < step, active: n === step }"
+      class="step-wrapper d-flex align-center"
     >
-      {{ n }}
+      <div
+        class="step-circle"
+        :class="{ done: n < step, active: n === step }"
+      >
+        {{ n }}
+      </div>
+      <div
+        v-if="n < total"
+        class="step-line"
+        :class="{ done: n < step }"
+      ></div>
     </div>
   </div>
 </template>
@@ -22,6 +31,10 @@ export default {
 </script>
 
 <style scoped>
+.step-wrapper {
+  display: flex;
+  align-items: center;
+}
 .step-circle {
   width: 28px;
   height: 28px;
@@ -32,10 +45,20 @@ export default {
   justify-content: center;
   color: var(--v-theme-secondary);
   font-weight: 500;
+  background-color: white;
+}
+.step-line {
+  width: 40px;
+  height: 2px;
+  background-color: var(--v-theme-secondary);
+  opacity: 0.3;
 }
 .step-circle.active,
 .step-circle.done {
   background-color: var(--v-theme-secondary);
   color: white;
+}
+.step-line.done {
+  opacity: 1;
 }
 </style>


### PR DESCRIPTION
## Summary
- improve progress display for the start flow StepIndicator
- include horizontal lines to show progress between numbered steps

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py` *(page smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_685ae7b416c883239b3e998cd901040a