### PR TITLE
Modularize tenant account and document tenant_id storage

### DIFF
--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -45,11 +45,16 @@ The function currently performs the following steps:
 
 1. Read the confirmed user's email from the event.
 2. Generate a short tenant identifier.
-3. Store the identifier in the Lambda response so downstream provisioning can
-   tag resources appropriately.
+3. Persist the identifier as a `tenant_id` custom attribute on the Cognito user
+   and include it in the Lambda response so downstream provisioning can tag
+  resources appropriately.
 
 The `saas` Terraform code builds and deploys this Lambda automatically and
 grants the user pool permission to invoke it.
+
+On subsequent logins the `tenant_id` attribute is included in the Cognito ID
+token, so the frontend can retrieve it along with the API endpoint URLs using
+`vue-jwt-decode`.
 
 ## Cost Reporting Lambda
 

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -44,7 +44,8 @@ purposes.
 The function currently performs the following steps:
 
 1. Read the confirmed user's email from the event.
-2. Generate a short tenant identifier.
+2. Generate a tenant identifier by appending the current UTC timestamp to a
+   short UUID.
 3. Persist the identifier as a `tenant_id` custom attribute on the Cognito user
    and include it in the Lambda response so downstream provisioning can tag
   resources appropriately.

--- a/docs/signup_flow.md
+++ b/docs/signup_flow.md
@@ -38,7 +38,7 @@ Storing the configuration in DynamoDB avoids Cognito's 2048 character limit for 
 
 ## 2. Post‑Verification Hook
 
-`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a short tenant identifier, stores it as the `tenant_id` custom attribute on the user and adds a placeholder `mc_api_url` attribute. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
+`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a tenant identifier by combining a short UUID with the current timestamp, stores it as the `tenant_id` custom attribute on the user and adds a placeholder `mc_api_url` attribute. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
 
 ```python
 codebuild.start_build(

--- a/docs/signup_flow.md
+++ b/docs/signup_flow.md
@@ -38,7 +38,7 @@ Storing the configuration in DynamoDB avoids Cognito's 2048 character limit for 
 
 ## 2. Post‑Verification Hook
 
-`saas/lambda/create_tenant.py` runs when the user confirms their account. The function now simply generates a tenant identifier and adds a placeholder `mc_api_url` attribute. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
+`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a short tenant identifier, stores it as the `tenant_id` custom attribute on the user and adds a placeholder `mc_api_url` attribute. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
 
 ```python
 codebuild.start_build(
@@ -52,6 +52,9 @@ codebuild.start_build(
 ```
 
 The build spec then passes these variables to Terraform so the infrastructure matches the selected options.
+
+The `tenant_id` attribute persists in Cognito, so the console can read it from
+the ID token on subsequent logins and include it in API requests.
 
 ## 3. Payment Integration
 

--- a/saas/lambda/create_tenant.py
+++ b/saas/lambda/create_tenant.py
@@ -1,6 +1,7 @@
 import boto3
 import logging
 import uuid
+from datetime import datetime
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -31,7 +32,7 @@ def handler(event, context):
         return event
 
 
-    tenant_id = str(uuid.uuid4())[:8]
+    tenant_id = f"{uuid.uuid4().hex[:8]}-{datetime.utcnow().strftime('%y%m%d%H%M')}"
     logger.info("Assigned tenant id %s to %s", tenant_id, email)
 
     event.setdefault("response", {})["tenant_info"] = {

--- a/saas/lambda/create_tenant.py
+++ b/saas/lambda/create_tenant.py
@@ -38,16 +38,17 @@ def handler(event, context):
         "tenant_id": tenant_id,
     }
 
-    # Ensure custom attributes exist for API endpoints
+    # Persist the new tenant ID along with other custom attributes
     try:
         cognito.admin_update_user_attributes(
             UserPoolId=user_pool_id,
             Username=username,
             UserAttributes=[
                 {"Name": "custom:mc_api_url", "Value": ""},
+                {"Name": "custom:tenant_id", "Value": tenant_id},
             ],
         )
-        logger.info("Initialized custom attribute for %s", username)
+        logger.info("Stored tenant id for %s", username)
     except Exception:
         logger.exception("Failed to set default attributes for %s", username)
 

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -10,6 +10,11 @@ module "frontend_site" {
   bucket_name = var.frontend_bucket_name
 }
 
+module "tenant_account" {
+  source               = "./modules/account"
+  tenant_account_email = var.tenant_account_email
+}
+
 locals {
   site_dir   = "${path.root}/../saas_web"
   site_files = fileset(local.site_dir, "**")
@@ -82,4 +87,8 @@ output "frontend_bucket" {
 
 output "frontend_url" {
   value = module.frontend_site.cloudfront_domain
+}
+
+output "tenant_account_id" {
+  value = module.tenant_account.tenant_account_id
 }

--- a/saas/modules/account/main.tf
+++ b/saas/modules/account/main.tf
@@ -2,7 +2,3 @@ resource "aws_organizations_account" "tenants" {
   name  = "minecraft-tenants"
   email = var.tenant_account_email
 }
-
-output "tenant_account_id" {
-  value = aws_organizations_account.tenants.id
-}

--- a/saas/modules/account/outputs.tf
+++ b/saas/modules/account/outputs.tf
@@ -1,0 +1,3 @@
+output "tenant_account_id" {
+  value = aws_organizations_account.tenants.id
+}

--- a/saas/modules/account/variables.tf
+++ b/saas/modules/account/variables.tf
@@ -1,0 +1,4 @@
+variable "tenant_account_email" {
+  description = "Email used for the shared tenant AWS account"
+  type        = string
+}

--- a/saas/modules/account/versions.tf
+++ b/saas/modules/account/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -32,6 +32,13 @@ EOF
     mutable             = true
   }
 
+  # Custom attribute storing the tenant identifier assigned during signup
+  schema {
+    attribute_data_type = "String"
+    name                = "tenant_id"
+    mutable             = true
+  }
+
   # Once a schema attribute is created it cannot be modified in place.
   # Terraform occasionally tries to update this block when provider
   # defaults change, which results in a failure.  Ignore any changes


### PR DESCRIPTION
## Summary
- move tenant account creation into its own Terraform module
- store generated tenant_id as a Cognito custom attribute
- explain how tenant_id persists in the docs

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=saas init -input=false`
- `terraform -chdir=saas validate`
- `html5validator --root saas_web`
- `python3 -m py_compile saas/lambda/create_tenant.py`


------
https://chatgpt.com/codex/tasks/task_e_685b33dc473c8323a883743452a6c1d5