### PR TITLE
Prefix tf resource names with minecraft

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -68,7 +68,7 @@ resource "aws_s3_object" "site" {
 }
 module "tenant_codebuild" {
   source         = "./modules/codebuild_provisioner"
-  project_name   = "tenant-terraform"
+  project_name   = "minecraft-tenant-terraform"
   repository_url = var.repository_url
 }
 

--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -56,7 +56,7 @@ resource "aws_cognito_user_pool_client" "this" {
 
 
 resource "aws_iam_role" "lambda" {
-  name = "create-tenant-role"
+  name = "minecraft-create-tenant-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
@@ -82,7 +82,7 @@ data "archive_file" "lambda_create_tenant" {
 resource "aws_lambda_function" "create_tenant" {
   filename         = data.archive_file.lambda_create_tenant.output_path
   source_code_hash = data.archive_file.lambda_create_tenant.output_base64sha256
-  function_name    = "create-tenant"
+  function_name    = "minecraft-create-tenant"
   role             = aws_iam_role.lambda.arn
   handler          = "create_tenant.handler"
   runtime          = "python3.11"

--- a/saas/modules/codebuild_provisioner/main.tf
+++ b/saas/modules/codebuild_provisioner/main.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "codebuild" {
 }
 
 resource "aws_iam_role_policy" "terraform" {
-  name = "codebuild-terraform-policy"
+  name = "minecraft-codebuild-terraform-policy"
   role = aws_iam_role.codebuild.id
 
   policy = jsonencode({

--- a/saas/modules/codebuild_provisioner/variables.tf
+++ b/saas/modules/codebuild_provisioner/variables.tf
@@ -6,7 +6,7 @@ variable "project_name" {
 variable "role_name" {
   description = "IAM role name for CodeBuild"
   type        = string
-  default     = "tenant-terraform-build"
+  default     = "minecraft-tenant-terraform-build"
 }
 
 variable "repository_url" {

--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -131,7 +131,7 @@ resource "aws_iam_role" "minecraft" {
   })
 
   inline_policy {
-    name = "s3-backup"
+    name = "minecraft-s3-backup"
     policy = jsonencode({
       Version = "2012-10-17"
       Statement = [{


### PR DESCRIPTION
## Summary
- add `minecraft` prefix to CodeBuild project name
- ensure IAM role and Lambda names include `minecraft`
- default the CodeBuild role name to a minecraft-prefixed string
- update inline policy name for backups

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `terraform init -backend=false` and `terraform validate` in `saas`
- `terraform init -backend=false` and `terraform validate` in `tenant`


------
https://chatgpt.com/codex/tasks/task_e_685b3e525ef883239a8172c1f7cfb227