### PR TITLE
Fix IAM for Cognito post-confirmation

### DIFF
--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -73,6 +73,20 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+resource "aws_iam_role_policy" "allow_update_user" {
+  name = "minecraft-create-tenant-userupdate"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["cognito-idp:AdminUpdateUserAttributes"],
+      Resource = aws_cognito_user_pool.this.arn
+    }]
+  })
+}
+
 data "archive_file" "lambda_create_tenant" {
   type        = "zip"
   source_file = "${path.module}/../../lambda/create_tenant.py"


### PR DESCRIPTION
## Summary
- allow the create_tenant lambda to update Cognito user attributes

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `html5validator --root saas_web`


------
https://chatgpt.com/codex/tasks/task_e_685b449ce2248323a6c49b542d7d2388