### PR TITLE
Remove mc_api_url attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ CloudFront distribution using an Origin Access Identity when
 `frontend_bucket_name` is set. The website files are uploaded automatically
 during `terraform apply`. The website files also receive the Cognito user pool
 ID and client ID which are inserted into a small helper module. The signup,
-verification and login components use the Amazon Cognito JavaScript SDK instead
-of raw API requests. The console reads the cost, start and status endpoints from
-custom attributes on the Cognito user after logging in using `vue-jwt-decode` to
-parse the token, so no manual placeholder replacement is required.
+ verification and login components use the Amazon Cognito JavaScript SDK instead
+ of raw API requests. After logging in the console decodes the ID token with
+ `vue-jwt-decode`, reads the `tenant_id` custom attribute and constructs the
+ cost, start and status URLs using this identifier. No manual placeholder
+ replacement is required.
 
 Example `terraform.tfvars` entries:
 

--- a/dev_server.py
+++ b/dev_server.py
@@ -51,7 +51,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 if __name__ == "__main__":
     dummy_token = (
         "eyJhbGciOiAibm9uZSJ9."
-        "eyJjdXN0b206bWNfYXBpX3VybCI6ICIvTUNfQVBJIn0=."
+        "eyJjdXN0b206dGVuYW50X2lkIjogImRlbW8ifQ==."
     )
 
     MOCK_RESPONSES.update(
@@ -59,9 +59,9 @@ if __name__ == "__main__":
             ("POST", "/SIGNUP_API_URL"): (200, None),
             ("POST", "/CONFIRM_API_URL"): (200, None),
             ("POST", "/LOGIN_API_URL"): (200, {"token": dummy_token}),
-            ("GET", "/MC_API/status"): (200, {"state": "offline"}),
-            ("POST", "/MC_API/start"): (200, None),
-            ("GET", "/MC_API/cost"): (200, {"total": 0}),
+            ("GET", "/MC_API/demo/status"): (200, {"state": "offline"}),
+            ("POST", "/MC_API/demo/start"): (200, None),
+            ("GET", "/MC_API/demo/cost"): (200, {"total": 0}),
         }
     )
 

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -16,9 +16,9 @@ provisioned when a user confirms their account.
 3. `terraform -chdir=saas apply` will automatically upload the contents of
    `saas_web` to the created S3 bucket. The Cognito user pool ID and client ID
    are injected directly into the Vue components so the frontend can use the
-   Amazon Cognito JavaScript SDK. The console reads the cost, start and status endpoints from
-   custom attributes on the Cognito user after login using the
-   `vue-jwt-decode` library to parse the token.
+   Amazon Cognito JavaScript SDK. After login the console decodes the ID token
+   with `vue-jwt-decode`, reads the `tenant_id` attribute and builds the cost,
+   start and status URLs from that identifier.
 
 ## Local Development
 

--- a/docs/signup_flow.md
+++ b/docs/signup_flow.md
@@ -38,7 +38,7 @@ Storing the configuration in DynamoDB avoids Cognito's 2048 character limit for 
 
 ## 2. Post‑Verification Hook
 
-`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a tenant identifier by combining a short UUID with the current timestamp, stores it as the `tenant_id` custom attribute on the user and adds a placeholder `mc_api_url` attribute. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
+`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a tenant identifier by combining a short UUID with the current timestamp and stores it as the `tenant_id` custom attribute on the user. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
 
 ```python
 codebuild.start_build(
@@ -54,7 +54,8 @@ codebuild.start_build(
 The build spec then passes these variables to Terraform so the infrastructure matches the selected options.
 
 The `tenant_id` attribute persists in Cognito, so the console can read it from
-the ID token on subsequent logins and include it in API requests.
+the ID token on subsequent logins and derive the API endpoint URLs
+using this identifier.
 
 ## 3. Payment Integration
 

--- a/saas/lambda/create_tenant.py
+++ b/saas/lambda/create_tenant.py
@@ -39,13 +39,12 @@ def handler(event, context):
         "tenant_id": tenant_id,
     }
 
-    # Persist the new tenant ID along with other custom attributes
+    # Persist the new tenant ID
     try:
         cognito.admin_update_user_attributes(
             UserPoolId=user_pool_id,
             Username=username,
             UserAttributes=[
-                {"Name": "custom:mc_api_url", "Value": ""},
                 {"Name": "custom:tenant_id", "Value": tenant_id},
             ],
         )

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -61,7 +61,9 @@ export default {
         localStorage.setItem('token', token);
         try {
           const payload = VueJwtDecode.decode(token);
-          const apiUrl = payload['custom:mc_api_url'] || '';
+          const tenantId = payload['custom:tenant_id'] || '';
+          const apiUrl = tenantId ? `/MC_API/${tenantId}` : '';
+          localStorage.setItem('tenant_id', tenantId);
           localStorage.setItem('api_url', apiUrl);
         } catch (e) {
           console.error('Failed to parse token', e);

--- a/saas_web/components/Verify.vue
+++ b/saas_web/components/Verify.vue
@@ -95,7 +95,9 @@ export default {
             localStorage.setItem('token', token);
             try {
               const payload = VueJwtDecode.decode(token);
-              const apiUrl = payload['custom:mc_api_url'] || '';
+              const tenantId = payload['custom:tenant_id'] || '';
+              const apiUrl = tenantId ? `/MC_API/${tenantId}` : '';
+              localStorage.setItem('tenant_id', tenantId);
               localStorage.setItem('api_url', apiUrl);
             } catch (e) {
               console.error('Failed to parse token', e);


### PR DESCRIPTION
## Summary
- drop the mc_api_url custom attribute
- derive endpoints from tenant_id throughout frontend
- adjust development server token and routes
- document new approach in README and docs

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685b47b3edcc8323bb8fbbc23e767faf