### PR TITLE
Add whitelist option and update StepConfig

### DIFF
--- a/docs/signup_flow.md
+++ b/docs/signup_flow.md
@@ -4,7 +4,7 @@ This document outlines how account creation data and server configuration flow t
 
 ## 1. Collecting Signup Data
 
-The landing page uses `saas_web/components/Start.vue` for new user registration. Besides the email and password fields, additional configuration such as player count or whether to pregenerate the world is collected. These values can be stored in a DynamoDB table keyed by the user name. Initially we considered passing them through Cognito custom attributes, but those have strict size limits. The SaaS layer now provisions a table named `minecraft-configs` with the following fields:
+The landing page uses `saas_web/components/Start.vue` for new user registration. Besides the email and password fields, additional configuration such as player count and optional whitelisted players is collected. These values can be stored in a DynamoDB table keyed by the user name. Initially we considered passing them through Cognito custom attributes, but those have strict size limits. The SaaS layer now provisions a table named `minecraft-configs` with the following fields:
 
 - **server_type** - vanilla or papermc
 - **instance_type** - EC2 instance type
@@ -46,7 +46,7 @@ codebuild.start_build(
     environmentVariablesOverride=[
         { 'name': 'TENANT_ID', 'value': tenant_id, 'type': 'PLAINTEXT' },
         { 'name': 'PLAYER_COUNT', 'value': players, 'type': 'PLAINTEXT' },
-        { 'name': 'PREGEN_WORLD', 'value': pregen, 'type': 'PLAINTEXT' },
+        { 'name': 'WHITELISTED_PLAYERS', 'value': ','.join(whitelisted_players), 'type': 'PLAINTEXT' },
     ],
 )
 ```

--- a/saas_web/components/start/StepConfig.vue
+++ b/saas_web/components/start/StepConfig.vue
@@ -4,9 +4,9 @@
       <v-select v-model="serverType" :items="serverTypeOptions" label="Server Type" required></v-select>
       <v-select v-model="instanceType" :items="instanceTypeOptions" label="Instance Type" required></v-select>
       <v-select v-model="players" :items="playerOptions" label="Players" required></v-select>
-      <v-text-field v-model.number="overworld" label="Overworld Border Radius" type="number" required></v-text-field>
-      <v-text-field v-model.number="nether" label="Nether Border Radius" type="number" required></v-text-field>
-      <v-checkbox v-model="pregen" label="Pregenerate world"></v-checkbox>
+      <v-text-field v-model="whitelist" label="Whitelisted Players (comma separated)"></v-text-field>
+      <v-text-field v-if="serverType === 'papermc'" v-model.number="overworld" label="Overworld Border Radius" type="number" required></v-text-field>
+      <v-text-field v-if="serverType === 'papermc'" v-model.number="nether" label="Nether Border Radius" type="number" required></v-text-field>
       <v-btn type="submit" color="secondary" class="mt-2">Launch</v-btn>
     </v-form>
     <div class="mt-2">{{ message }}</div>
@@ -19,14 +19,14 @@ export default {
   name: 'StepConfig',
   data() {
     return {
-      serverType: 'papermc',
+      serverType: 'vanilla',
       instanceType: 't4g.medium',
       players: 4,
+      whitelist: '',
       overworld: 3000,
       nether: 3000,
-      pregen: false,
       message: '',
-      serverTypeOptions: ['papermc', 'vanilla'],
+      serverTypeOptions: ['vanilla', 'papermc'],
       instanceTypeOptions: ['t4g.small', 't4g.medium', 't4g.large'],
       playerOptions: Array.from({ length: 20 }, (_, i) => i + 1),
     };
@@ -56,9 +56,16 @@ export default {
             server_type: this.serverType,
             instance_type: this.instanceType,
             players: this.players,
-            pregen: this.pregen,
-            overworld_border: this.overworld,
-            nether_border: this.nether,
+            whitelisted_players: this.whitelist
+              .split(',')
+              .map((p) => p.trim())
+              .filter((p) => p.length > 0),
+            ...(this.serverType === 'papermc'
+              ? {
+                  overworld_border: this.overworld,
+                  nether_border: this.nether,
+                }
+              : {}),
           }),
         });
         if (!res.ok) throw new Error('failed');

--- a/tenant/user_data.sh
+++ b/tenant/user_data.sh
@@ -3,8 +3,11 @@ set -euo pipefail
 # This variable is replaced by Terraform at deploy time
 # shellcheck disable=SC2269
 BACKUP_BUCKET="${BACKUP_BUCKET}"
+# shellcheck disable=SC2269
 SERVER_TYPE="${SERVER_TYPE}"
+# shellcheck disable=SC2269
 OVERWORLD_RADIUS="${OVERWORLD_RADIUS}"
+# shellcheck disable=SC2269
 NETHER_RADIUS="${NETHER_RADIUS}"
 
 LOG_FILE=/var/log/minecraft-setup.log
@@ -37,9 +40,11 @@ cd /home/ec2-user/minecraft || exit
 # Download server jar based on type
 if [ "$SERVER_TYPE" = "vanilla" ]; then
   wget https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar -O server.jar
+  # shellcheck disable=SC2034
   JAR_NAME="server.jar"
 else
   wget https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds/225/downloads/paper-1.21.4-225.jar -O paper.jar
+  # shellcheck disable=SC2034
   JAR_NAME="paper.jar"
 fi
 echo "eula=true" > eula.txt


### PR DESCRIPTION
## Summary
- include whitelisted player list in the signup StepConfig
- remove pregenerate toggle
- default server type is now vanilla
- world border inputs hidden unless papermc selected
- adjust signup flow docs
- silence shellcheck warnings

## Testing
- `html5validator --root saas_web`
- `terraform fmt -recursive`
- `shellcheck tenant/user_data.sh`
- `python dev_server.py` *(started then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685b4facc5248323b77e60fd736dea02