### PR TITLE
Remove tenant attribute update and adjust docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ during `terraform apply`. The website files also receive the Cognito user pool
 ID and client ID which are inserted into a small helper module. The signup,
  verification and login components use the Amazon Cognito JavaScript SDK instead
  of raw API requests. After logging in the console decodes the ID token with
- `vue-jwt-decode`, reads the `tenant_id` custom attribute and constructs the
- cost, start and status URLs using this identifier. No manual placeholder
+ `vue-jwt-decode` and constructs the cost, start and status URLs using the
+ tenant identifier returned during provisioning. No manual placeholder
  replacement is required.
 
 Example `terraform.tfvars` entries:

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -16,9 +16,9 @@ provisioned when a user confirms their account.
 3. `terraform -chdir=saas apply` will automatically upload the contents of
    `saas_web` to the created S3 bucket. The Cognito user pool ID and client ID
    are injected directly into the Vue components so the frontend can use the
-   Amazon Cognito JavaScript SDK. After login the console decodes the ID token
-   with `vue-jwt-decode`, reads the `tenant_id` attribute and builds the cost,
-   start and status URLs from that identifier.
+  Amazon Cognito JavaScript SDK. After login the console decodes the ID token
+  with `vue-jwt-decode` and builds the cost, start and status URLs using the
+  tenant identifier returned during signup.
 
 ## Local Development
 
@@ -46,16 +46,14 @@ The function currently performs the following steps:
 1. Read the confirmed user's email from the event.
 2. Generate a tenant identifier by appending the current UTC timestamp to a
    short UUID.
-3. Persist the identifier as a `tenant_id` custom attribute on the Cognito user
-   and include it in the Lambda response so downstream provisioning can tag
-  resources appropriately.
+3. Include the identifier in the Lambda response so downstream provisioning can
+   tag resources appropriately.
 
 The `saas` Terraform code builds and deploys this Lambda automatically and
 grants the user pool permission to invoke it.
 
-On subsequent logins the `tenant_id` attribute is included in the Cognito ID
-token, so the frontend can retrieve it along with the API endpoint URLs using
-`vue-jwt-decode`.
+On subsequent logins the console can retrieve the tenant identifier from its
+stored configuration rather than the Cognito ID token.
 
 ## Cost Reporting Lambda
 

--- a/docs/signup_flow.md
+++ b/docs/signup_flow.md
@@ -38,7 +38,7 @@ Storing the configuration in DynamoDB avoids Cognito's 2048 character limit for 
 
 ## 2. Post‑Verification Hook
 
-`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a tenant identifier by combining a short UUID with the current timestamp and stores it as the `tenant_id` custom attribute on the user. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
+`saas/lambda/create_tenant.py` runs when the user confirms their account. The function generates a tenant identifier by combining a short UUID with the current timestamp and includes it in the Lambda response. It can also read the custom attributes or look up the pending configuration in DynamoDB. The values are included when triggering the CodeBuild provisioning project:
 
 ```python
 codebuild.start_build(
@@ -53,9 +53,9 @@ codebuild.start_build(
 
 The build spec then passes these variables to Terraform so the infrastructure matches the selected options.
 
-The `tenant_id` attribute persists in Cognito, so the console can read it from
-the ID token on subsequent logins and derive the API endpoint URLs
-using this identifier.
+The tenant identifier is passed along during provisioning rather than being
+stored in Cognito. The console retains this value locally to derive the API
+endpoint URLs.
 
 ## 3. Payment Integration
 

--- a/saas/lambda/create_tenant.py
+++ b/saas/lambda/create_tenant.py
@@ -1,12 +1,9 @@
-import boto3
 import logging
 import uuid
 from datetime import datetime
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
-
-cognito = boto3.client("cognito-idp")
 
 
 
@@ -19,19 +16,6 @@ def handler(event, context):
         logger.error("Email not found in event")
         return event
 
-    try:
-        user_pool_id = event["userPoolId"]
-    except KeyError:
-        logger.error("userPoolId not found in event")
-        return event
-
-    try:
-        username = event["userName"]
-    except KeyError:
-        logger.error("userName not found in event")
-        return event
-
-
     tenant_id = f"{uuid.uuid4().hex[:8]}-{datetime.utcnow().strftime('%y%m%d%H%M')}"
     logger.info("Assigned tenant id %s to %s", tenant_id, email)
 
@@ -39,19 +23,6 @@ def handler(event, context):
         "tenant_id": tenant_id,
     }
 
-    # Persist the new tenant ID
-    try:
-        cognito.admin_update_user_attributes(
-            UserPoolId=user_pool_id,
-            Username=username,
-            UserAttributes=[
-                {"Name": "custom:tenant_id", "Value": tenant_id},
-            ],
-        )
-        logger.info("Stored tenant id for %s", username)
-    except Exception:
-        logger.exception("Failed to set default attributes for %s", username)
-        return { "statusCode": 500, "body": "Failed to set default attributes" }
     
     logger.debug("Returning event: %s", event)
 


### PR DESCRIPTION
## Summary
- stop using the Cognito SDK in `create_tenant.py`
- update documentation to reflect that the tenant ID is only returned via the Lambda response

## Testing
- `python -m py_compile saas/lambda/create_tenant.py`
- `html5validator --root saas_web`
- `terraform fmt -recursive`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`


------
https://chatgpt.com/codex/tasks/task_e_685b4d0b1a4883239a2a819fa69624ea