### PR TITLE
Fix auto login by enabling SRP auth

### DIFF
--- a/saas/modules/auth/main.tf
+++ b/saas/modules/auth/main.tf
@@ -42,9 +42,13 @@ EOF
 }
 
 resource "aws_cognito_user_pool_client" "this" {
-  name                = var.client_name
-  user_pool_id        = aws_cognito_user_pool.this.id
-  explicit_auth_flows = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  name         = var.client_name
+  user_pool_id = aws_cognito_user_pool.this.id
+  explicit_auth_flows = [
+    "ALLOW_USER_PASSWORD_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+  ]
 }
 
 

--- a/tenant/user_data.sh
+++ b/tenant/user_data.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -euo pipefail
-# shellcheck disable=SC2269,SC2034
-# This variable is replaced by Terraform at deploy time
+# This variable block is replaced by Terraform at deploy time
+# shellcheck disable=SC2034,SC2269
 BACKUP_BUCKET="${BACKUP_BUCKET}"
+# shellcheck disable=SC2034,SC2269
 SERVER_TYPE="${SERVER_TYPE}"
+# shellcheck disable=SC2034,SC2269
 OVERWORLD_RADIUS="${OVERWORLD_RADIUS}"
+# shellcheck disable=SC2034,SC2269
 NETHER_RADIUS="${NETHER_RADIUS}"
 
 LOG_FILE=/var/log/minecraft-setup.log


### PR DESCRIPTION
## Summary
- enable `ALLOW_USER_SRP_AUTH` on the Cognito user pool client so the frontend can authenticate with SRP

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `html5validator --root saas_web`

------
https://chatgpt.com/codex/tasks/task_e_685b7d8aee48832392de5157b77346c9