### PR TITLE
Add init endpoint for tenant API

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -30,7 +30,7 @@ locals {
     "CONFIRM_API_URL"     = module.auth.confirm_api_url
     "USER_POOL_ID"        = module.auth.user_pool_id
     "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id
-    "INIT_SERVER_API_URL" = var.init_server_api_url
+    "INIT_SERVER_API_URL" = "${module.tenant_api.api_url}/init"
   }
 
   processed_files = {
@@ -113,7 +113,7 @@ output "tenant_account_id" {
 output "tenant_api_url" {
   value = module.tenant_api.api_url
 }
-  
+
 output "backup_bucket" {
   value = module.backup_bucket.bucket_name
 }

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -30,11 +30,6 @@ variable "tenant_account_email" {
   type        = string
 }
 
-variable "init_server_api_url" {
-  description = "API Gateway URL for initiating tenant infrastructure"
-  type        = string
-}
-
 variable "backup_bucket_name" {
   description = "S3 bucket for centralized tenant backups"
   type        = string


### PR DESCRIPTION
## Summary
- support server provisioning via new `init` endpoint
- bake the init server endpoint URL directly from tenant API output
- drop unused `init_server_api_url` variable

## Testing
- `terraform fmt -recursive`
- `pip install html5validator`
- `html5validator --root saas_web`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`

------
https://chatgpt.com/codex/tasks/task_e_685c14aae84083239fd350a6b3330542