### PR TITLE
Update dev server for tenant API paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,6 @@ python3 dev_server.py
 ```
 
 This serves the files from `saas_web` and mocks the various API endpoints so the
-forms and console can be tested without deploying any backend, including a dummy
-`/MC_API/cost` used on the console page.
+forms and console can be tested without deploying any backend. The development
+server also simulates the tenant API paths like `/MC_API/<tenant_id>/cost` used
+on the console page.

--- a/dev_server.py
+++ b/dev_server.py
@@ -6,6 +6,7 @@ import http.server
 import json
 import os
 import logging
+import re
 from functools import partial
 
 PORT = 8000
@@ -20,8 +21,16 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         super().end_headers()
 
+    def _normalized_path(self, path):
+        """Collapse tenant-specific API paths to generic ones."""
+        m = re.match(r"^/MC_API/[^/]+/(.*)$", path)
+        if m:
+            return f"/MC_API/{m.group(1)}"
+        return path
+
     def do_GET(self):
-        resp = MOCK_RESPONSES.get(("GET", self.path))
+        path = self._normalized_path(self.path)
+        resp = MOCK_RESPONSES.get(("GET", path))
         if resp:
             status, body = resp
             self.send_response(status)
@@ -34,7 +43,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         super().do_GET()
 
     def do_POST(self):
-        resp = MOCK_RESPONSES.get(("POST", self.path))
+        path = self._normalized_path(self.path)
+        resp = MOCK_RESPONSES.get(("POST", path))
         if resp:
             status, body = resp
             self.send_response(status)

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -30,8 +30,8 @@ python3 dev_server.py --site saas_web
 ```
 
 This serves the site at <http://localhost:8000> and mocks all API endpoints so
-signup, login and the console work offline, including a fake cost API used on
-the console page.
+signup, login and the console work offline. It simulates the tenant API paths
+such as `/MC_API/<tenant_id>/cost` for the console page.
 
 ## Post Confirmation Hook
 


### PR DESCRIPTION
## Summary
- update `dev_server` to normalize tenant API paths
- clarify README and saas setup docs about `/MC_API/<tenant_id>` usage

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python -m py_compile dev_server.py`


------
https://chatgpt.com/codex/tasks/task_e_685c19bbf14883239c9cfd8973048b97