### PR TITLE
Fix dynamic loader by dropping ES module imports

### DIFF
--- a/saas_web/components/App.vue
+++ b/saas_web/components/App.vue
@@ -20,9 +20,9 @@
 </template>
 
 <script>
-import { computed } from 'vue';
-import { useRouter } from 'vue-router';
-import { useAuthStore } from '../store.js';
+const { computed } = Vue;
+const { useRouter } = VueRouter;
+const useAuthStore = window.useAuthStore;
 export default {
   name: 'App',
   setup() {

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import VueJwtDecode from 'vue-jwt-decode'
+const VueJwtDecode = window['vue-jwt-decode'];
 
 const poolData = {
   UserPoolId: 'USER_POOL_ID',

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -19,8 +19,8 @@
 </template>
 
 <script>
-import VueJwtDecode from 'vue-jwt-decode'
-import { useAuthStore } from '../store.js';
+const VueJwtDecode = window['vue-jwt-decode'];
+const useAuthStore = window.useAuthStore;
 
 const poolData = {
   UserPoolId: 'USER_POOL_ID',

--- a/saas_web/components/Verify.vue
+++ b/saas_web/components/Verify.vue
@@ -22,8 +22,8 @@
 </template>
 
 <script>
-import VueJwtDecode from 'vue-jwt-decode'
-import { useAuthStore } from '../store.js';
+const VueJwtDecode = window['vue-jwt-decode'];
+const useAuthStore = window.useAuthStore;
 
 const poolData = {
   UserPoolId: 'USER_POOL_ID',

--- a/saas_web/components/start/StepAccount.vue
+++ b/saas_web/components/start/StepAccount.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import { useAuthStore } from '../../store.js';
+const useAuthStore = window.useAuthStore;
 const poolData = {
   UserPoolId: 'USER_POOL_ID',
   ClientId: 'USER_POOL_CLIENT_ID',

--- a/saas_web/components/start/StepConfig.vue
+++ b/saas_web/components/start/StepConfig.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import VueJwtDecode from 'vue-jwt-decode'
+const VueJwtDecode = window['vue-jwt-decode'];
 export default {
   name: 'StepConfig',
   data() {

--- a/saas_web/store.js
+++ b/saas_web/store.js
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia';
+const { defineStore } = Pinia;
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -10,3 +10,4 @@ export const useAuthStore = defineStore('auth', {
     },
   },
 });
+window.useAuthStore = useAuthStore;


### PR DESCRIPTION
## Summary
- remove `import` statements in Vue SFCs
- rely on global variables for vue-router, pinia, and jwt decode
- expose `useAuthStore` globally

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685c20ff34e8832384d815b36dff7cfb