### PR TITLE
Fix dynamic component paths

### DIFF
--- a/saas_web/components/Start.vue
+++ b/saas_web/components/Start.vue
@@ -17,16 +17,16 @@ export default {
   name: 'Start',
   components: {
     StepAccount: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./start/StepAccount.vue', window.loaderOptions)
+      window['vue3-sfc-loader'].loadModule('./components/start/StepAccount.vue', window.loaderOptions)
     ),
     StepPayment: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./start/StepPayment.vue', window.loaderOptions)
+      window['vue3-sfc-loader'].loadModule('./components/start/StepPayment.vue', window.loaderOptions)
     ),
     StepConfig: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./start/StepConfig.vue', window.loaderOptions)
+      window['vue3-sfc-loader'].loadModule('./components/start/StepConfig.vue', window.loaderOptions)
     ),
     StepIndicator: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./start/StepIndicator.vue', window.loaderOptions)
+      window['vue3-sfc-loader'].loadModule('./components/start/StepIndicator.vue', window.loaderOptions)
     ),
   },
   data() {


### PR DESCRIPTION
## Summary
- fix paths for async components in Start page

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685c30cd94ac8323a5e415dbcb32e43a