### PR TITLE
Fix async component paths and add global variable

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -37,31 +37,31 @@ locals {
     for f in local.site_files :
     f => endswith(f, "favicon.ico") ? filebase64("${local.site_dir}/${f}") : replace(
       replace(
-      replace(
-        replace(
         replace(
           replace(
-          file("${local.site_dir}/${f}"),
-          "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
+            replace(
+              replace(
+                file("${local.site_dir}/${f}"),
+                "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
+              ),
+              "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
+            ),
+            "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
           ),
-          "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
+          "USER_POOL_ID", local.placeholders["USER_POOL_ID"]
         ),
-        "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
-        ),
-        "USER_POOL_ID", local.placeholders["USER_POOL_ID"]
-      ),
-      "USER_POOL_CLIENT_ID", local.placeholders["USER_POOL_CLIENT_ID"]
+        "USER_POOL_CLIENT_ID", local.placeholders["USER_POOL_CLIENT_ID"]
       ),
       "INIT_SERVER_API_URL", local.placeholders["INIT_SERVER_API_URL"]
     )
-    }
+  }
 
   mime_types = {
     html = "text/html"
     js   = "application/javascript"
     css  = "text/css"
     vue  = "text/plain"
-    ico = "image/x-icon"
+    ico  = "image/x-icon"
   }
 }
 

--- a/saas_web/components/Home.vue
+++ b/saas_web/components/Home.vue
@@ -27,7 +27,7 @@ export default {
   name: 'Home',
   components: {
     CostCalculator: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./CostCalculator.vue', window.loaderOptions)
+      window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/CostCalculator.vue`, window.loaderOptions)
     ),
   },
 };

--- a/saas_web/components/Pricing.vue
+++ b/saas_web/components/Pricing.vue
@@ -34,7 +34,7 @@ export default {
   name: 'Pricing',
   components: {
     CostCalculator: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./CostCalculator.vue', window.loaderOptions)
+      window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/CostCalculator.vue`, window.loaderOptions)
     ),
   },
 };

--- a/saas_web/components/Start.vue
+++ b/saas_web/components/Start.vue
@@ -15,20 +15,20 @@
 <script>
 export default {
   name: 'Start',
-  components: {
-    StepAccount: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./components/start/StepAccount.vue', window.loaderOptions)
-    ),
-    StepPayment: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./components/start/StepPayment.vue', window.loaderOptions)
-    ),
-    StepConfig: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./components/start/StepConfig.vue', window.loaderOptions)
-    ),
-    StepIndicator: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule('./components/start/StepIndicator.vue', window.loaderOptions)
-    ),
-  },
+    components: {
+      StepAccount: Vue.defineAsyncComponent(() =>
+        window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/start/StepAccount.vue`, window.loaderOptions)
+      ),
+      StepPayment: Vue.defineAsyncComponent(() =>
+        window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/start/StepPayment.vue`, window.loaderOptions)
+      ),
+      StepConfig: Vue.defineAsyncComponent(() =>
+        window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/start/StepConfig.vue`, window.loaderOptions)
+      ),
+      StepIndicator: Vue.defineAsyncComponent(() =>
+        window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/start/StepIndicator.vue`, window.loaderOptions)
+      ),
+    },
   data() {
     return { step: 1 };
   },

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -19,24 +19,25 @@ const options = {
   },
 };
 window.loaderOptions = options;
+window.componentsPath = './components';
 
 (async () => {
   const [App] = await Promise.all([
-    window['vue3-sfc-loader'].loadModule('./components/App.vue', options),
+    window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/App.vue`, options),
   ]);
 
   const router = VueRouter.createRouter({
     history: VueRouter.createWebHistory(),
     routes: [
-      { path: '/', component: () => window['vue3-sfc-loader'].loadModule('./components/Home.vue', options) },
-      { path: '/pricing', component: () => window['vue3-sfc-loader'].loadModule('./components/Pricing.vue', options) },
-      { path: '/support', component: () => window['vue3-sfc-loader'].loadModule('./components/Support.vue', options) },
-      { path: '/about', component: () => window['vue3-sfc-loader'].loadModule('./components/About.vue', options) },
-      { path: '/login', component: () => window['vue3-sfc-loader'].loadModule('./components/Login.vue', options) },
-      { path: '/console', component: () => window['vue3-sfc-loader'].loadModule('./components/Console.vue', options) },
-      { path: '/start', component: () => window['vue3-sfc-loader'].loadModule('./components/Start.vue', options) },
-      { path: '/verify', component: () => window['vue3-sfc-loader'].loadModule('./components/Verify.vue', options) },
-      { path: '/:pathMatch(.*)*', component: () => window['vue3-sfc-loader'].loadModule('./components/NotFound.vue', options) },
+      { path: '/', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Home.vue`, options) },
+      { path: '/pricing', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Pricing.vue`, options) },
+      { path: '/support', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Support.vue`, options) },
+      { path: '/about', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/About.vue`, options) },
+      { path: '/login', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Login.vue`, options) },
+      { path: '/console', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Console.vue`, options) },
+      { path: '/start', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Start.vue`, options) },
+      { path: '/verify', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Verify.vue`, options) },
+      { path: '/:pathMatch(.*)*', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/NotFound.vue`, options) },
     ],
   });
 


### PR DESCRIPTION
## Summary
- add a global `componentsPath` variable in `main.js`
- use that variable for router component imports
- update async component imports in `Home.vue`, `Pricing.vue` and `Start.vue`
- run `terraform fmt` which adjusted `saas/main.tf`

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py` then `curl -I http://localhost:8000/` and `curl -I http://localhost:8000/components/CostCalculator.vue`

------
https://chatgpt.com/codex/tasks/task_e_685c3419e2ac83238921dead3457c9bf