### PR TITLE
Add console init and redirect

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             ("POST", "/SIGNUP_API_URL"): (200, None),
             ("POST", "/CONFIRM_API_URL"): (200, None),
             ("POST", "/LOGIN_API_URL"): (200, {"token": dummy_token}),
-            ("POST", "/INIT_SERVER_API_URL"): (200, None),
+            ("POST", "/MC_API/init"): (200, None),
             ("GET", "/MC_API/status"): (200, {"state": "offline"}),
             ("POST", "/MC_API/start"): (200, None),
             ("GET", "/MC_API/cost"): (200, {"total": 0}),

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -25,13 +25,11 @@ locals {
   site_dir   = "${path.root}/../saas_web"
   site_files = fileset(local.site_dir, "**")
   placeholders = {
-    "SIGNUP_API_URL"      = module.auth.signup_api_url
-    "LOGIN_API_URL"       = module.auth.login_api_url
-    "CONFIRM_API_URL"     = module.auth.confirm_api_url
-    "USER_POOL_ID"        = module.auth.user_pool_id
-    "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id
-    "INIT_SERVER_API_URL" = "${module.tenant_api.api_url}/init"
-  }
+    "SIGNUP_API_URL"  = module.auth.signup_api_url
+    "LOGIN_API_URL"   = module.auth.login_api_url
+    "CONFIRM_API_URL" = module.auth.confirm_api_url
+    "USER_POOL_ID"    = module.auth.user_pool_id
+  "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id }
 
   processed_files = {
     for f in local.site_files :
@@ -40,19 +38,16 @@ locals {
         replace(
           replace(
             replace(
-              replace(
-                file("${local.site_dir}/${f}"),
-                "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
-              ),
-              "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
+              file("${local.site_dir}/${f}"),
+              "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
             ),
-            "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
+            "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
           ),
-          "USER_POOL_ID", local.placeholders["USER_POOL_ID"]
+          "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
         ),
-        "USER_POOL_CLIENT_ID", local.placeholders["USER_POOL_CLIENT_ID"]
+        "USER_POOL_ID", local.placeholders["USER_POOL_ID"]
       ),
-      "INIT_SERVER_API_URL", local.placeholders["INIT_SERVER_API_URL"]
+      "USER_POOL_CLIENT_ID", local.placeholders["USER_POOL_CLIENT_ID"]
     )
   }
 

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -6,6 +6,8 @@
       <div>{{ status }}</div>
       <div class="mt-2">{{ cost }}</div>
       <v-btn v-if="showStart" @click="start" class="mt-2">Start Server</v-btn>
+      <h3 class="text-h6 mt-8 mb-2">Start a New Server</h3>
+      <StepConfig @complete="fetchStatus" />
       </v-col>
     </v-row>
   </v-container>
@@ -14,6 +16,14 @@
 <script>
 export default {
   name: 'Console',
+  components: {
+    StepConfig: Vue.defineAsyncComponent(() =>
+      window['vue3-sfc-loader'].loadModule(
+        `${window.componentsPath}/start/StepConfig.vue`,
+        window.loaderOptions,
+      ),
+    ),
+  },
   data() {
     return {
       status: 'Checking status...',

--- a/saas_web/components/start/StepConfig.vue
+++ b/saas_web/components/start/StepConfig.vue
@@ -29,9 +29,14 @@ export default {
       serverTypeOptions: ['vanilla', 'papermc'],
       instanceTypeOptions: ['t4g.small', 't4g.medium', 't4g.large'],
       playerOptions: Array.from({ length: 20 }, (_, i) => i + 1),
+      api_url: '/MC_API',
     };
   },
   methods: {
+    endpoint(path) {
+      const normalizedApiUrl = this.api_url.replace(/\/+$/, '');
+      return `${normalizedApiUrl}/${path}`;
+    },
     async initTenantServer() {
       this.message = 'Provisioning your server...';
       const token = localStorage.getItem('token');
@@ -45,7 +50,7 @@ export default {
         }
       }
       try {
-        const res = await fetch('INIT_SERVER_API_URL', {
+        const res = await fetch(this.endpoint('init'), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -62,7 +62,11 @@ window.componentsPath = './components';
 
   router.beforeEach((to, from, next) => {
     auth.updateLoggedIn();
-    next();
+    if (to.path === '/start' && auth.loggedIn) {
+      next('/console');
+    } else {
+      next();
+    }
   });
 
   Vue.createApp(App).use(router).use(vuetify).use(pinia).mount('#app');


### PR DESCRIPTION
## Summary
- remove INIT_SERVER_API_URL placeholder from SaaS terraform
- redirect logged-in users from `/start` to the console
- call the `init` endpoint using `/MC_API` base
- show StepConfig on the console page
- support `/MC_API/init` in the dev server

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3e9b8e24832388b083ce03746f39