### PR TITLE
Fix API URL replacement for console

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ during `terraform apply`. The website files also receive the Cognito user pool
 ID and client ID which are inserted into a small helper module. The signup,
 verification and login components use the Amazon Cognito JavaScript SDK instead
 of raw API requests. After logging in the console simply includes the ID token
-in requests to the fixed `/MC_API` endpoints. The backend derives the tenant
-identifier from the token so no manual placeholder replacement is required.
+in requests to the API endpoint injected during deployment. The backend derives
+the tenant identifier from the token so no manual placeholder replacement is
+required.
 
 Example `terraform.tfvars` entries:
 

--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -18,8 +18,8 @@ provisioned when a user confirms their account.
    `saas_web` to the created S3 bucket. The Cognito user pool ID and client ID
    are injected directly into the Vue components so the frontend can use the
   Amazon Cognito JavaScript SDK. After login the console simply sends the ID
-  token with requests to `/MC_API` and the backend determines the tenant from
-  the JWT claims.
+  token to the API endpoint injected during deployment and the backend
+  determines the tenant from the JWT claims.
 
 ## Local Development
 

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -31,6 +31,7 @@ locals {
     "USER_POOL_ID"        = module.auth.user_pool_id
     "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id
     "INIT_SERVER_API_URL" = "${module.tenant_api.api_url}/init"
+    "MC_API_URL"          = module.tenant_api.api_url
   }
 
   processed_files = {
@@ -41,7 +42,10 @@ locals {
           replace(
             replace(
               replace(
-                file("${local.site_dir}/${f}"),
+                replace(
+                  file("${local.site_dir}/${f}"),
+                  "MC_API_URL", local.placeholders["MC_API_URL"]
+                ),
                 "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
               ),
               "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -25,22 +25,13 @@ locals {
   site_dir   = "${path.root}/../saas_web"
   site_files = fileset(local.site_dir, "**")
   placeholders = {
-<<<<<<< codex/replace-api-url-placeholder-in-site-and-terraform
     "SIGNUP_API_URL"      = module.auth.signup_api_url
     "LOGIN_API_URL"       = module.auth.login_api_url
     "CONFIRM_API_URL"     = module.auth.confirm_api_url
     "USER_POOL_ID"        = module.auth.user_pool_id
     "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id
-    "INIT_SERVER_API_URL" = "${module.tenant_api.api_url}/init"
     "MC_API_URL"          = module.tenant_api.api_url
   }
-=======
-    "SIGNUP_API_URL"  = module.auth.signup_api_url
-    "LOGIN_API_URL"   = module.auth.login_api_url
-    "CONFIRM_API_URL" = module.auth.confirm_api_url
-    "USER_POOL_ID"    = module.auth.user_pool_id
-  "USER_POOL_CLIENT_ID" = module.auth.user_pool_client_id }
->>>>>>> main
 
   processed_files = {
     for f in local.site_files :
@@ -49,7 +40,6 @@ locals {
         replace(
           replace(
             replace(
-<<<<<<< codex/replace-api-url-placeholder-in-site-and-terraform
               replace(
                 replace(
                   file("${local.site_dir}/${f}"),
@@ -58,10 +48,6 @@ locals {
                 "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
               ),
               "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
-=======
-              file("${local.site_dir}/${f}"),
-              "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
->>>>>>> main
             ),
             "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
           ),

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -20,7 +20,7 @@ export default {
       showStart: false,
       cost: 'Fetching cost...',
       interval: null,
-      api_url: '/MC_API',
+      api_url: MC_API_URL,
       };
     },
   mounted() {

--- a/saas_web/components/start/StepConfig.vue
+++ b/saas_web/components/start/StepConfig.vue
@@ -29,7 +29,7 @@ export default {
       serverTypeOptions: ['vanilla', 'papermc'],
       instanceTypeOptions: ['t4g.small', 't4g.medium', 't4g.large'],
       playerOptions: Array.from({ length: 20 }, (_, i) => i + 1),
-      api_url: '/MC_API',
+      api_url: 'MC_API_URL',
     };
   },
   methods: {


### PR DESCRIPTION
## Summary
- fix API url placeholder in Console.vue
- inject `MC_API_URL` placeholder during SaaS deployment
- clarify docs about injected API endpoint

## Testing
- `python3 dev_server.py` *(served site locally)*
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `html5validator --root saas_web`


------
https://chatgpt.com/codex/tasks/task_e_685c405d8e34832392b9db19d6db7331