### PR TITLE
Enable CORS for tenant API

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -91,6 +91,7 @@ module "tenant_api" {
   user_pool_id        = module.auth.user_pool_id
   user_pool_client_id = module.auth.user_pool_client_id
   region              = var.region
+  allowed_origins     = ["https://${module.frontend_site.cloudfront_domain}"]
 }
 
 

--- a/saas/modules/tenant_api/main.tf
+++ b/saas/modules/tenant_api/main.tf
@@ -114,6 +114,13 @@ resource "aws_lambda_permission" "apigw_init" {
 resource "aws_apigatewayv2_api" "this" {
   name          = "tenant-api"
   protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_headers     = ["Authorization", "Content-Type"]
+    allow_methods     = ["GET", "POST", "OPTIONS"]
+    allow_origins     = var.allowed_origins
+    allow_credentials = true
+  }
 }
 
 resource "aws_apigatewayv2_authorizer" "jwt" {

--- a/saas/modules/tenant_api/variables.tf
+++ b/saas/modules/tenant_api/variables.tf
@@ -12,3 +12,8 @@ variable "region" {
   description = "AWS region"
   type        = string
 }
+
+variable "allowed_origins" {
+  description = "Origins allowed to call this API"
+  type        = list(string)
+}

--- a/saas/modules/tenant_api/variables.tf
+++ b/saas/modules/tenant_api/variables.tf
@@ -16,4 +16,8 @@ variable "region" {
 variable "allowed_origins" {
   description = "Origins allowed to call this API"
   type        = list(string)
+  validation {
+    condition     = alltrue([for origin in var.allowed_origins : can(regex("^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$", origin))])
+    error_message = "Each entry in allowed_origins must be a valid URL starting with http:// or https://."
+  }
 }


### PR DESCRIPTION
## Summary
- allow SaaS frontend to call tenant API by adding CORS configuration

## Testing
- `terraform fmt -recursive`
- `terraform init -input=false`
- `terraform validate`
- `html5validator --root saas_web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c451343f88323b08f6d5fda7a1a72