### PR TITLE
Add Cognito token refresh support

### DIFF
--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -43,7 +43,8 @@ export default {
   },
   methods: {
     // No initialization needed; the backend uses the JWT to determine the tenant
-  authHeader() {
+  async authHeader() {
+      await window.refreshTokenIfNeeded();
       const token = localStorage.getItem('token');
       return token ? { Authorization: `Bearer ${token}` } : {};
     },
@@ -54,7 +55,7 @@ export default {
     async fetchStatus() {
       try {
         const res = await fetch(this.endpoint('status'), {
-          headers: this.authHeader(),
+          headers: await this.authHeader(),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
@@ -75,7 +76,7 @@ export default {
       this.showStart = false;
       this.status = 'Starting...';
       try {
-        const res = await fetch(this.endpoint('start'), { method: 'POST', headers: this.authHeader() });
+        const res = await fetch(this.endpoint('start'), { method: 'POST', headers: await this.authHeader() });
         if (!res.ok) throw new Error('Failed');
       } catch (err) {
         console.error(err);
@@ -86,7 +87,7 @@ export default {
     async fetchCost() {
       try {
         const res = await fetch(this.endpoint('cost'), {
-          headers: this.authHeader(),
+          headers: await this.authHeader(),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();

--- a/saas_web/components/Login.vue
+++ b/saas_web/components/Login.vue
@@ -56,7 +56,9 @@ export default {
         });
 
         const token = session.getIdToken().getJwtToken();
+        const refreshToken = session.getRefreshToken().getToken();
         localStorage.setItem('token', token);
+        localStorage.setItem('refreshToken', refreshToken);
         this.message = 'Logged in!';
         this.$router.push('/console');
       } catch (err) {

--- a/saas_web/components/Verify.vue
+++ b/saas_web/components/Verify.vue
@@ -90,7 +90,9 @@ export default {
               });
             });
             const token = session.getIdToken().getJwtToken();
+            const refreshToken = session.getRefreshToken().getToken();
             localStorage.setItem('token', token);
+            localStorage.setItem('refreshToken', refreshToken);
             sessionStorage.removeItem('pendingCreds');
             loggedIn = true;
           } catch (e) {

--- a/saas_web/components/start/StepAccount.vue
+++ b/saas_web/components/start/StepAccount.vue
@@ -163,7 +163,9 @@ export default {
         try {
           const session = await this.loginUser(this.email, this.password);
           const token = session.getIdToken().getJwtToken();
+          const refreshToken = session.getRefreshToken().getToken();
           localStorage.setItem('token', token);
+          localStorage.setItem('refreshToken', refreshToken);
           useAuthStore().updateLoggedIn();
         } catch (e) {
           console.error('Auto login failed', e);

--- a/saas_web/components/start/StepConfig.vue
+++ b/saas_web/components/start/StepConfig.vue
@@ -39,6 +39,7 @@ export default {
     },
     async initTenantServer() {
       this.message = 'Provisioning your server...';
+      await window.refreshTokenIfNeeded();
       const token = localStorage.getItem('token');
       let tenantId = '';
       if (token) {

--- a/saas_web/store.js
+++ b/saas_web/store.js
@@ -1,4 +1,11 @@
 const { defineStore } = Pinia;
+const VueJwtDecode = window['vue-jwt-decode'];
+
+const poolData = {
+  UserPoolId: 'USER_POOL_ID',
+  ClientId: 'USER_POOL_CLIENT_ID',
+};
+const userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
 
 const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -10,4 +17,46 @@ const useAuthStore = defineStore('auth', {
     },
   },
 });
+
+async function refreshTokenIfNeeded() {
+  const token = localStorage.getItem('token');
+  const refreshTokenStr = localStorage.getItem('refreshToken');
+  if (!token || !refreshTokenStr) return;
+  let payload;
+  try {
+    payload = VueJwtDecode.decode(token);
+  } catch (e) {
+    console.error('Token decode failed', e);
+    return;
+  }
+  const exp = payload.exp || 0;
+  const now = Date.now() / 1000;
+  if (exp - now > 60) return; // still valid
+  const username = payload['cognito:username'] || payload.email || '';
+  const cognitoUser = new AmazonCognitoIdentity.CognitoUser({
+    Username: username,
+    Pool: userPool,
+  });
+  const refreshToken = new AmazonCognitoIdentity.CognitoRefreshToken({
+    RefreshToken: refreshTokenStr,
+  });
+  try {
+    const session = await new Promise((resolve, reject) => {
+      cognitoUser.refreshSession(refreshToken, (err, session) => {
+        if (err) return reject(err);
+        resolve(session);
+      });
+    });
+    localStorage.setItem('token', session.getIdToken().getJwtToken());
+    localStorage.setItem('refreshToken', session.getRefreshToken().getToken());
+    useAuthStore().updateLoggedIn();
+  } catch (err) {
+    console.error('Token refresh failed', err);
+    localStorage.removeItem('token');
+    localStorage.removeItem('refreshToken');
+    useAuthStore().updateLoggedIn();
+  }
+}
+
 window.useAuthStore = useAuthStore;
+window.refreshTokenIfNeeded = refreshTokenIfNeeded;


### PR DESCRIPTION
## Summary
- store refresh tokens when logging in or verifying accounts
- add global `refreshTokenIfNeeded` helper in `store.js`
- refresh the token before tenant API calls

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py` (served index.html successfully)


------
https://chatgpt.com/codex/tasks/task_e_685c4b6764d48323923b11a835be5c6c