### PR TITLE
Fix script paths for SPA routes

### DIFF
--- a/saas_web/index.html
+++ b/saas_web/index.html
@@ -39,7 +39,7 @@
   <script src="https://cdn.jsdelivr.net/npm/vue3-sfc-loader@0.9.5/dist/vue3-sfc-loader.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/amazon-cognito-identity-js@6.3.15/dist/amazon-cognito-identity.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vue-jwt-decode@0.1.0/dist/lib/vue-jwt-decode.min.js"></script>
-  <script src="./store.js"></script>
-  <script type="module" src="./main.js"></script>
+  <script src="/store.js"></script>
+  <script type="module" src="/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load scripts from site root so SPA works on nested routes

## Testing
- `html5validator --root saas_web --show-warnings -l`
- `terraform fmt -recursive`
- `terraform init -backend=false` *(in saas and tenant)*
- `terraform validate` *(in saas and tenant)*
- `python tests/test_console.py`

------
https://chatgpt.com/codex/tasks/task_e_685c64e4531c83239436964e3363eb41