### PR TITLE
Fix init_server CodeBuild permission

### DIFF
--- a/saas/modules/tenant_api/main.tf
+++ b/saas/modules/tenant_api/main.tf
@@ -31,6 +31,11 @@ resource "aws_iam_role_policy" "tenant_permissions" {
         Effect   = "Allow",
         Action   = ["ce:GetCostAndUsage"],
         Resource = "*"
+      },
+      {
+        Effect   = "Allow",
+        Action   = ["codebuild:StartBuild"],
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- allow the API Lambda to start the tenant CodeBuild project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_685ed9ba8f888323b6d4a9905144e586