### PR TITLE
Fix jq install in CodeBuild buildspec

### DIFF
--- a/saas/modules/codebuild_provisioner/buildspec.yml
+++ b/saas/modules/codebuild_provisioner/buildspec.yml
@@ -8,7 +8,8 @@ phases:
       - curl -Lo terraform.zip https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip
       - unzip terraform.zip
       - mv terraform /usr/local/bin/terraform
-      - yum install -y jq
+      - apt-get update -y
+      - apt-get install -y jq
   build:
     commands:
       - git clone $REPOSITORY_URL repo


### PR DESCRIPTION
## Summary
- update buildspec to use `apt-get` instead of `yum`

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`


------
https://chatgpt.com/codex/tasks/task_e_685ee5908388832386e53b09da619c5c