### PR TITLE
Expose RCON and root access

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,15 @@ http://localhost:8000/#/debug-config
 
 These load the payment and configuration steps in isolation so layout or API
 issues can be inspected without navigating through the full wizard.
+
+## Server Access
+
+The EC2 instance allows SSH login directly as `root` using the same key
+configured for the `ec2-user` account. Remote connections should use the
+server's IPv6 address which remains constant while the instance exists. The
+Minecraft server exposes its RCON port (25575) so tools like `mcrcon` can be
+used from your local machine:
+
+```bash
+mcrcon -H <server IPv6> -P 25575 -p minecraft "list"
+```

--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -21,10 +21,11 @@ resource "aws_security_group" "minecraft" {
   }
 
   ingress {
-    from_port   = 25575
-    to_port     = 25575
-    protocol    = "tcp"
-    cidr_blocks = ["127.0.0.1/32"]
+    from_port        = 25575
+    to_port          = 25575
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {

--- a/tenant/user_data.sh
+++ b/tenant/user_data.sh
@@ -32,8 +32,17 @@ cd /tmp || exit
 wget https://corretto.aws/downloads/latest/amazon-corretto-21-aarch64-linux-jdk.rpm
 yum localinstall -y amazon-corretto-21-aarch64-linux-jdk.rpm
 
-sudo yum groupinstall -y "Development Tools"          
+sudo yum groupinstall -y "Development Tools"
 yum install -y wget unzip aws-cli cronie python3 nc git make gcc
+
+# Enable root SSH login using the same key as ec2-user
+mkdir -p /root/.ssh
+if [ -f /home/ec2-user/.ssh/authorized_keys ]; then
+  cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/authorized_keys
+  chmod 600 /root/.ssh/authorized_keys
+fi
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+systemctl restart sshd
 
 mkdir -p /home/ec2-user/minecraft
 sudo chmod -R 777 /home/ec2-user/minecraft


### PR DESCRIPTION
## Summary
- allow RCON port from the internet
- permit root SSH login on the instance
- document how to use the IPv6 address and rcon

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` and `terraform validate` in `tenant`
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685ef83019188323ba764d4c1043ea0c