### PR TITLE
Generate tenant key pair and use default VPC

### DIFF
--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -3,15 +3,20 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnets" "default" {
+data "aws_subnets" "public" {
   filter {
     name   = "vpc-id"
     values = [data.aws_vpc.default.id]
   }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
 }
 
-data "aws_subnet" "default" {
-  id = data.aws_subnets.default.ids[0]
+data "aws_subnet" "public" {
+  id = data.aws_subnets.public.ids[0]
 }
 
 resource "tls_private_key" "tenant" {
@@ -102,7 +107,7 @@ data "aws_ami" "amazon_linux" {
 resource "aws_instance" "minecraft" {
   ami                    = data.aws_ami.amazon_linux.id
   instance_type          = var.instance_type
-  subnet_id              = data.aws_subnet.default.id
+  subnet_id              = data.aws_subnet.public.id
   vpc_security_group_ids = [aws_security_group.minecraft.id]
   key_name               = aws_key_pair.tenant.key_name
   iam_instance_profile   = aws_iam_instance_profile.minecraft.name

--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -1,8 +1,33 @@
 
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_subnet" "default" {
+  id = data.aws_subnets.default.ids[0]
+}
+
+resource "tls_private_key" "tenant" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "tenant" {
+  key_name   = "${var.tenant_id}-key"
+  public_key = tls_private_key.tenant.public_key_openssh
+}
+
 resource "aws_security_group" "minecraft" {
   name        = "minecraft_sg"
   description = "Allow SSH and Minecraft"
-  vpc_id      = var.vpc_id
+  vpc_id      = data.aws_vpc.default.id
 
   ingress {
     from_port        = 22
@@ -77,9 +102,9 @@ data "aws_ami" "amazon_linux" {
 resource "aws_instance" "minecraft" {
   ami                    = data.aws_ami.amazon_linux.id
   instance_type          = var.instance_type
-  subnet_id              = var.subnet_id
+  subnet_id              = data.aws_subnet.default.id
   vpc_security_group_ids = [aws_security_group.minecraft.id]
-  key_name               = var.key_pair_name
+  key_name               = aws_key_pair.tenant.key_name
   iam_instance_profile   = aws_iam_instance_profile.minecraft.name
   ipv6_address_count     = 1
 
@@ -274,5 +299,10 @@ output "start_minecraft_api_url" {
 
 output "status_minecraft_api_url" {
   value = aws_api_gateway_stage.status.invoke_url
+}
+
+output "key_pair_private_key" {
+  value     = tls_private_key.tenant.private_key_pem
+  sensitive = true
 }
 

--- a/tenant/terraform.tfvars.example
+++ b/tenant/terraform.tfvars.example
@@ -1,8 +1,5 @@
 region = "us-east-1"
-key_pair_name = "minecraft-server-key"
 backup_bucket_name = "example-backup-bucket"
-vpc_id = "vpc-xxxxxxxx"
-subnet_id = "subnet-xxxxxxxx"
 tenant_id = "example"
 server_type = "papermc"
 instance_type = "t4g.medium"

--- a/tenant/variables.tf
+++ b/tenant/variables.tf
@@ -3,10 +3,6 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "key_pair_name" {
-  description = "Name of an existing EC2 key pair"
-  type        = string
-}
 
 variable "backup_bucket_name" {
   description = "Unique S3 bucket name for world backups"
@@ -14,15 +10,6 @@ variable "backup_bucket_name" {
   default     = "minecraft-saas-backups"
 }
 
-variable "vpc_id" {
-  description = "VPC for the security group"
-  type        = string
-}
-
-variable "subnet_id" {
-  description = "Subnet for the EC2 instance"
-  type        = string
-}
 
 
 variable "tenant_id" {


### PR DESCRIPTION
## Summary
- generate a key pair for each tenant using `tls_private_key` and `aws_key_pair`
- use the default VPC and its first subnet for EC2 instances
- remove `key_pair_name`, `vpc_id` and `subnet_id` variables

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=tenant init -input=false`
- `terraform -chdir=tenant validate`
- `html5validator --root saas_web`


------
https://chatgpt.com/codex/tasks/task_e_685f531804208323b2e50d28b0c3404d