### PR TITLE
Add privacy page

### DIFF
--- a/docs/data_privacy.md
+++ b/docs/data_privacy.md
@@ -1,0 +1,15 @@
+# Data Privacy
+
+We are committed to safeguarding both your account details and any data stored on your Minecraft server. Only the minimal information required to run our service is collected.
+
+## No Selling of Your Data
+
+We never sell or share your personal information or server data with third parties. Details such as your email, payment information and world files are used solely so you can manage your server.
+
+## Protections in Place
+
+- **Whitelist/blacklist controls** allow you to explicitly permit or deny players.
+- **DDoS mitigation** through AWS Shield and network firewalls helps keep your server online.
+- Backups and logs are stored securely with restricted access.
+
+Your worlds remain your property and can be deleted at any time from the console.

--- a/saas_web/components/App.vue
+++ b/saas_web/components/App.vue
@@ -7,6 +7,7 @@
       <v-spacer></v-spacer>
       <v-btn to="/pricing" variant="text" router>Pricing</v-btn>
       <v-btn to="/support" variant="text" router>Support</v-btn>
+      <v-btn to="/privacy" variant="text" router>Privacy</v-btn>
       <v-btn to="/about" variant="text" router>About Us</v-btn>
       <v-btn v-if="!loggedIn" to="/login" variant="text" router>Login</v-btn>
       <v-btn v-if="loggedIn" @click="logout" variant="text">Logout</v-btn>

--- a/saas_web/components/DataPrivacy.vue
+++ b/saas_web/components/DataPrivacy.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-container>
+    <v-row class="mb-6">
+      <v-col>
+        <h2 class="text-h5"><i class="fas fa-user-secret mr-2"></i>Data Privacy</h2>
+        <p>We collect only what we need to run your server and keep it secure.</p>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col>
+        <h2 class="text-h5"><i class="fas fa-hands mr-2"></i>Your Data is Yours</h2>
+        <p>We never sell your personal information or world data to third parties. It is used solely to provide our services.</p>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col>
+        <h2 class="text-h5"><i class="fas fa-shield-alt mr-2"></i>Security and Protections</h2>
+        <p>Your servers are protected with whitelist and blacklist controls plus DDoS mitigation on our network.</p>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'DataPrivacy',
+};
+</script>
+
+<style scoped>
+</style>

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -32,6 +32,7 @@ window.componentsPath = './components';
       { path: '/', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Home.vue`, options) },
       { path: '/pricing', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Pricing.vue`, options) },
       { path: '/support', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Support.vue`, options) },
+      { path: '/privacy', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/DataPrivacy.vue`, options) },
       { path: '/about', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/About.vue`, options) },
       { path: '/login', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Login.vue`, options) },
       { path: '/console', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Console.vue`, options) },


### PR DESCRIPTION
## Summary
- add data privacy documentation
- create new Privacy page for the site
- hook privacy route and navigation button

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686303f186408323bb4173d07c75f248