### PR TITLE
Fix IPv6 subnet assumption in tenant module

### DIFF
--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -26,7 +26,7 @@ resource "aws_vpc_ipv6_cidr_block_association" "default" {
 }
 
 locals {
-  vpc_ipv6_cidr_block = data.aws_vpc.default.ipv6_cidr_block != "" ? data.aws_vpc.default.ipv6_cidr_block : aws_vpc_ipv6_cidr_block_association.default[0].ipv6_cidr_block
+  vpc_ipv6_cidr_block = data.aws_vpc.default.ipv6_cidr_block != "" ? data.aws_vpc.default.ipv6_cidr_block : (length(aws_vpc_ipv6_cidr_block_association.default) > 0 ? aws_vpc_ipv6_cidr_block_association.default[0].ipv6_cidr_block : null)
 }
 
 resource "null_resource" "associate_subnet_ipv6" {


### PR DESCRIPTION
## Summary
- associate IPv6 CIDR block with default VPC and public subnet
- restore IPv6 rules and usage
- replace deprecated inline IAM policies with `aws_iam_role_policy`

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=tenant init -input=false`
- `terraform -chdir=tenant validate`
- `html5validator --root saas_web`


------
https://chatgpt.com/codex/tasks/task_e_686353d353288323b28d00a4614e6cb4