### PR TITLE
Choose public subnet for EC2 server

### DIFF
--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -10,7 +10,7 @@ data "aws_subnets" "public" {
   }
 
   filter {
-    name   = "default-for-az"
+    name   = "map-public-ip-on-launch"
     values = ["true"]
   }
 }


### PR DESCRIPTION
## Summary
- ensure Terraform picks a subnet that assigns public IPs when creating the Minecraft server

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `terraform -chdir=tenant init`
- `terraform -chdir=tenant validate`

------
https://chatgpt.com/codex/tasks/task_e_68645acde2c48323a014ef3c52c99ea9