### PR TITLE
Fix tenant TF backend usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Minecraft server SaaS with AWS.
 
 ### Terraform
 
+
 ```
 cd tenant
-terraform init    # downloads providers
+# initialize with the remote state bucket and lock table created by the SaaS layer
+terraform init \
+  -backend-config="bucket=YOUR_STATE_BUCKET" \
+  -backend-config="key=YOUR_TENANT/terraform.tfstate" \
+  -backend-config="dynamodb_table=YOUR_LOCK_TABLE"
 terraform apply   # creates resources (requires AWS credentials)
 ```
 

--- a/tenant/backend.tf
+++ b/tenant/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}


### PR DESCRIPTION
## Summary
- configure tenant terraform to use remote S3 backend
- document backend usage in README

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `terraform init -backend=false` in `tenant`
- `terraform validate` in `tenant`


------
https://chatgpt.com/codex/tasks/task_e_686456e6f61c8323afc546d7d77f15a3