### PR TITLE
Hide new server form when a stack exists

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -71,10 +71,11 @@ if __name__ == "__main__":
             ("POST", "/CONFIRM_API_URL"): (200, None),
             ("POST", "/LOGIN_API_URL"): (200, {"token": dummy_token}),
             ("POST", "/MC_API/init"): (200, {"build_id": "demo-build"}),
-            ("GET", "/MC_API/status"): (200, {"state": "offline"}),
+            ("GET", "/MC_API/status"): (200, {"state": "offline", "exists": False}),
             ("POST", "/MC_API/start"): (200, None),
             ("GET", "/MC_API/cost"): (200, {"total": 0}),
             ("POST", "/MC_API/checkout"): (200, {"client_secret": "seti_dummy"}),
+            ("POST", "/MC_API/delete"): (200, None),
         }
     )
 

--- a/saas/lambda/delete_stack.py
+++ b/saas/lambda/delete_stack.py
@@ -1,0 +1,37 @@
+import json
+import logging
+import os
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+codebuild = boto3.client("codebuild")
+PROJECT_NAME = os.environ.get("PROJECT_NAME", "minecraft-tenant-terraform")
+
+
+def handler(event, context):
+    """Trigger CodeBuild to destroy the tenant stack."""
+    claims = (
+        event.get("requestContext", {})
+        .get("authorizer", {})
+        .get("jwt", {})
+        .get("claims", {})
+    )
+    tenant_id = claims.get("custom:tenant_id")
+    if not tenant_id:
+        return {"statusCode": 400, "body": json.dumps({"error": "missing tenant_id"})}
+
+    params = [
+        {"name": "TENANT_ID", "value": tenant_id, "type": "PLAINTEXT"},
+        {"name": "ACTION", "value": "destroy", "type": "PLAINTEXT"},
+    ]
+
+    try:
+        codebuild.start_build(projectName=PROJECT_NAME, environmentVariablesOverride=params)
+    except Exception:
+        logger.exception("Failed to start destroy build")
+        return {"statusCode": 500, "body": json.dumps({"error": "internal"})}
+
+    return {"statusCode": 200, "body": json.dumps({"status": "started"})}
+

--- a/saas/lambda/delete_stack.py
+++ b/saas/lambda/delete_stack.py
@@ -29,8 +29,11 @@ def handler(event, context):
 
     try:
         codebuild.start_build(projectName=PROJECT_NAME, environmentVariablesOverride=params)
-    except Exception:
-        logger.exception("Failed to start destroy build")
+    except botocore.exceptions.ClientError as e:
+        logger.exception(f"ClientError while starting destroy build: {e}")
+        return {"statusCode": 500, "body": json.dumps({"error": "AWS ClientError"})}
+    except Exception as e:
+        logger.exception(f"Unexpected error while starting destroy build: {e}")
         return {"statusCode": 500, "body": json.dumps({"error": "internal"})}
 
     return {"statusCode": 200, "body": json.dumps({"status": "started"})}

--- a/saas/lambda/server_status.py
+++ b/saas/lambda/server_status.py
@@ -30,8 +30,13 @@ def handler(event, context):
 
     state = "offline"
     reservations = resp.get("Reservations", [])
+    exists = bool(reservations)
     if reservations:
         instance = reservations[0]["Instances"][0]
         state = instance.get("State", {}).get("Name", "unknown")
 
-    return {"statusCode": 200, "body": json.dumps({"state": state})}
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"state": state, "exists": exists}),
+    }
+

--- a/saas/modules/codebuild_provisioner/buildspec.yml
+++ b/saas/modules/codebuild_provisioner/buildspec.yml
@@ -20,9 +20,15 @@ phases:
             -backend-config="key=$TENANT_ID/terraform.tfstate" \
             -backend-config="dynamodb_table=$LOCK_TABLE"
       - |
-          terraform apply -auto-approve -input=false \
-            -var "tenant_id=$TENANT_ID" \
-            -var "server_type=$SERVER_TYPE" \
-            -var "instance_type=$INSTANCE_TYPE" \
-            -var "overworld_border_radius=$OVERWORLD_BORDER" \
-            -var "nether_border_radius=$NETHER_BORDER"
+          if [ "$ACTION" = "destroy" ]; then
+            terraform destroy -auto-approve -input=false \
+              -var "tenant_id=$TENANT_ID"
+          else
+            terraform apply -auto-approve -input=false \
+              -var "tenant_id=$TENANT_ID" \
+              -var "server_type=$SERVER_TYPE" \
+              -var "instance_type=$INSTANCE_TYPE" \
+              -var "overworld_border_radius=$OVERWORLD_BORDER" \
+              -var "nether_border_radius=$NETHER_BORDER"
+          fi
+

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -7,8 +7,9 @@
       <div class="mt-2">{{ cost }}</div>
       <div v-if="progress" class="mt-2">{{ progress }}</div>
       <v-btn v-if="showStart" @click="start" class="mt-2">Start Server</v-btn>
-      <h3 class="text-h6 mt-8 mb-2">Start a New Server</h3>
-      <StepConfig @complete="handleInitComplete" />
+      <v-btn v-if="serverExists" @click="deleteStack" class="mt-2" color="error">Delete Server</v-btn>
+      <h3 v-if="!serverExists" class="text-h6 mt-8 mb-2">Start a New Server</h3>
+      <StepConfig v-if="!serverExists" @complete="handleInitComplete" />
       </v-col>
     </v-row>
   </v-container>
@@ -35,6 +36,7 @@ export default {
       progressInterval: null,
       progress: '',
       buildId: '',
+      serverExists: false,
       api_url: 'MC_API_URL',
       };
     },
@@ -70,13 +72,14 @@ export default {
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
+        this.serverExists = data.exists ?? false;
         if (data.state === 'running') {
           const players = data.players ?? 0;
           this.status = `Server is running with ${players} player${players === 1 ? '' : 's'} online.`;
           this.showStart = false;
         } else {
-          this.status = 'Server is offline.';
-          this.showStart = true;
+          this.status = this.serverExists ? 'Server is offline.' : 'No server found.';
+          this.showStart = this.serverExists;
         }
       } catch (err) {
         console.error(err);
@@ -149,9 +152,26 @@ export default {
         this.progress = 'Error fetching build status.';
       }
     },
+
+    async deleteStack() {
+      try {
+        const res = await fetch(this.endpoint('delete'), {
+          method: 'POST',
+          headers: await this.authHeader(),
+        });
+        if (!res.ok) throw new Error('failed');
+        this.serverExists = false;
+        this.showStart = false;
+        this.status = 'Deletion started.';
+      } catch (err) {
+        console.error(err);
+        this.status = 'Failed to delete server.';
+      }
+    },
   },
 };
 </script>
 
 <style scoped>
 </style>
+

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -7,7 +7,10 @@
       <div class="mt-2">{{ cost }}</div>
       <div v-if="progress" class="mt-2">{{ progress }}</div>
       <v-btn v-if="showStart" @click="start" class="mt-2">Start Server</v-btn>
-      <v-btn v-if="serverExists" @click="deleteStack" class="mt-2" color="error">Delete Server</v-btn>
+      <v-btn v-if="serverExists" :disabled="deleting" @click="deleteStack" class="mt-2" color="error">
+        <span v-if="!deleting">Delete Server</span>
+        <span v-else>Deleting...</span>
+      </v-btn>
       <h3 v-if="!serverExists" class="text-h6 mt-8 mb-2">Start a New Server</h3>
       <StepConfig v-if="!serverExists" @complete="handleInitComplete" />
       </v-col>

--- a/tenant/main.tf
+++ b/tenant/main.tf
@@ -134,12 +134,12 @@ resource "aws_instance" "minecraft" {
   iam_instance_profile   = aws_iam_instance_profile.minecraft.name
   ipv6_address_count     = 1
 
+  tags = local.common_tags
+
   root_block_device {
     volume_size = 30
     volume_type = "gp3"
-    tags = merge({
-      CostCenter = var.tenant_id
-    }, var.tags)
+    tags        = local.common_tags
   }
 
   user_data = templatefile("${path.module}/user_data.sh", {

--- a/tenant/versions.tf
+++ b/tenant/versions.tf
@@ -9,11 +9,20 @@ terraform {
   }
 }
 
+locals {
+  # Common tags applied to all AWS resources for this tenant
+  common_tags = merge(
+    var.tags,
+    {
+      tenant_id  = var.tenant_id
+      CostCenter = var.tenant_id
+    }
+  )
+}
+
 provider "aws" {
   region = var.region
   default_tags {
-    tags = merge({
-      CostCenter = var.tenant_id
-    }, var.tags)
+    tags = local.common_tags
   }
 }


### PR DESCRIPTION
## Summary
- show server info only after provisioning and hide Start form
- allow deleting a tenant stack from the console
- support destroy via CodeBuild
- mock delete endpoint in development server

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` && `terraform validate`
- `html5validator --root saas_web`
- `pytest -q` *(fails: no tests found)*
- `python tests/test_console.py` *(failed: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686498c32a0c8323bd7214163a300814