### PR TITLE
Display block buddy sprites

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -42,31 +42,35 @@ locals {
 
   processed_files = {
     for f in local.site_files :
-    f => endswith(f, "favicon.ico") ? filebase64("${local.site_dir}/${f}") : replace(
-      replace(
+    f => {
+      # PNGs and favicon are binary assets that must be uploaded using base64.
+      binary = endswith(lower(f), ".png") || endswith(f, "favicon.ico")
+      content = (endswith(lower(f), ".png") || endswith(f, "favicon.ico")) ? filebase64("${local.site_dir}/${f}") : replace(
         replace(
           replace(
             replace(
               replace(
                 replace(
                   replace(
-                    file("${local.site_dir}/${f}"),
-                    "MC_API_URL", local.placeholders["MC_API_URL"]
+                    replace(
+                      file("${local.site_dir}/${f}"),
+                      "MC_API_URL", local.placeholders["MC_API_URL"]
+                    ),
+                    "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
                   ),
-                  "SIGNUP_API_URL", local.placeholders["SIGNUP_API_URL"]
+                  "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
                 ),
                 "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
               ),
-              "LOGIN_API_URL", local.placeholders["LOGIN_API_URL"]
+              "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
             ),
-            "CONFIRM_API_URL", local.placeholders["CONFIRM_API_URL"]
+            "USER_POOL_ID", local.placeholders["USER_POOL_ID"]
           ),
-          "USER_POOL_ID", local.placeholders["USER_POOL_ID"]
+          "USER_POOL_CLIENT_ID", local.placeholders["USER_POOL_CLIENT_ID"]
         ),
-        "USER_POOL_CLIENT_ID", local.placeholders["USER_POOL_CLIENT_ID"]
-      ),
-      "STRIPE_PUBLISHABLE_KEY", local.placeholders["STRIPE_PUBLISHABLE_KEY"]
-    )
+        "STRIPE_PUBLISHABLE_KEY", local.placeholders["STRIPE_PUBLISHABLE_KEY"]
+      )
+    }
   }
 
   mime_types = {
@@ -75,20 +79,22 @@ locals {
     css  = "text/css"
     vue  = "text/plain"
     ico  = "image/x-icon"
+    png  = "image/png"
   }
 }
 
 resource "aws_s3_object" "site" {
-  for_each = local.processed_files
-  bucket   = module.frontend_site.bucket_name
-  key      = each.key
-  content  = each.value
+  for_each       = local.processed_files
+  bucket         = module.frontend_site.bucket_name
+  key            = each.key
+  content        = each.value.binary ? null : each.value.content
+  content_base64 = each.value.binary ? each.value.content : null
   content_type = lookup(
     local.mime_types,
     lower(element(reverse(split(".", each.key)), 0)),
     "text/plain",
   )
-  etag = md5(each.value)
+  etag = md5(each.value.content)
 }
 module "tenant_codebuild" {
   source            = "./modules/codebuild_provisioner"

--- a/saas_web/404.html
+++ b/saas_web/404.html
@@ -24,10 +24,20 @@
     }
     a { color: #81d4fa; }
     h1 { color: #b39ddb; }
+    .block-buddy {
+      width: 128px;
+      height: 128px;
+      background-image: url('assets/emerald_block_buddies.png');
+      background-size: 256px 256px;
+      background-position: 0 -128px;
+      image-rendering: pixelated;
+      margin-bottom: 1rem;
+    }
   </style>
 </head>
 <body>
   <div id="container">
+    <div class="block-buddy"></div>
     <i class="fas fa-question-circle fa-3x" style="margin-bottom: 1rem;"></i>
     <h1>404 - Page Not Found</h1>
     <p><a href="/">Return Home</a></p>

--- a/saas_web/50x.html
+++ b/saas_web/50x.html
@@ -24,10 +24,20 @@
     }
     a { color: #81d4fa; }
     h1 { color: #b39ddb; }
+    .block-buddy {
+      width: 128px;
+      height: 128px;
+      background-image: url('assets/iron_ore_buddies.png');
+      background-size: 256px 256px;
+      background-position: -128px -128px;
+      image-rendering: pixelated;
+      margin-bottom: 1rem;
+    }
   </style>
 </head>
 <body>
   <div id="container">
+    <div class="block-buddy"></div>
     <i class="fas fa-exclamation-triangle fa-3x" style="margin-bottom: 1rem;"></i>
     <h1>Oops! Something went wrong.</h1>
     <p>Please try again later. <a href="/">Return Home</a></p>

--- a/saas_web/components/About.vue
+++ b/saas_web/components/About.vue
@@ -1,5 +1,8 @@
 <template>
     <v-container>
+      <v-row class="justify-center mb-4">
+        <BlockBuddy sheet="emerald" :index="2" />
+      </v-row>
       <v-row class="mb-6">
         <v-col>
           <h2 class="text-h5"><i class="fas fa-info-circle mr-2"></i>About Us</h2>
@@ -26,6 +29,11 @@
   <script>
   export default {
     name: 'About',
+    components: {
+      BlockBuddy: Vue.defineAsyncComponent(() =>
+        window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/BlockBuddy.vue`, window.loaderOptions)
+      ),
+    },
   };
   </script>
   

--- a/saas_web/components/BlockBuddy.vue
+++ b/saas_web/components/BlockBuddy.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="block-buddy" :style="style"></div>
+</template>
+
+<script>
+export default {
+  name: 'BlockBuddy',
+  props: {
+    sheet: { type: String, default: 'emerald' },
+    index: { type: Number, default: 0 },
+  },
+  computed: {
+    style() {
+      const sheets = {
+        emerald: 'assets/emerald_block_buddies.png',
+        iron: 'assets/iron_ore_buddies.png',
+      };
+      const pos = [
+        '0px 0px',
+        '-128px 0px',
+        '0px -128px',
+        '-128px -128px',
+      ];
+      return {
+        width: '128px',
+        height: '128px',
+        'background-image': `url(${sheets[this.sheet] || sheets.emerald})`,
+        'background-size': '256px 256px',
+        'background-position': pos[this.index % 4],
+        'image-rendering': 'pixelated',
+      };
+    },
+  },
+};
+</script>
+
+<style scoped>
+.block-buddy {
+  display: inline-block;
+}
+</style>

--- a/saas_web/components/BlockBuddy.vue
+++ b/saas_web/components/BlockBuddy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="block-buddy" :style="style"></div>
+  <div class="block-buddy" :style="style" aria-hidden="true"></div>
 </template>
 
 <script>

--- a/saas_web/components/Home.vue
+++ b/saas_web/components/Home.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
     <v-container>
+      <v-row class="justify-center mb-4">
+        <BlockBuddy sheet="emerald" :index="0" />
+      </v-row>
       <v-row class="mb-6">
         <v-col>
           <h2 class="text-h5"><i class="fas fa-users mr-2"></i>Small servers, big fun</h2>
@@ -28,6 +31,9 @@ export default {
   components: {
     CostCalculator: Vue.defineAsyncComponent(() =>
       window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/CostCalculator.vue`, window.loaderOptions)
+    ),
+    BlockBuddy: Vue.defineAsyncComponent(() =>
+      window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/BlockBuddy.vue`, window.loaderOptions)
     ),
   },
 };

--- a/saas_web/components/Support.vue
+++ b/saas_web/components/Support.vue
@@ -1,5 +1,8 @@
 <template>
   <v-container>
+    <v-row class="justify-center mb-4">
+      <BlockBuddy sheet="iron" :index="1" />
+    </v-row>
     <v-row>
       <v-col>
         <h2 class="text-h5"><i class="fas fa-question-circle mr-2"></i>FAQ</h2>
@@ -14,6 +17,11 @@
 <script>
 export default {
   name: 'Support',
+  components: {
+    BlockBuddy: Vue.defineAsyncComponent(() =>
+      window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/BlockBuddy.vue`, window.loaderOptions)
+    ),
+  },
 };
 </script>
 


### PR DESCRIPTION
## Summary
- add BlockBuddy component to slice spritesheets
- drop sample sprites on 404 and 50x pages
- display buddies on Home, About, and Support pages

## Testing
- `html5validator --root saas_web`
- `terraform fmt -recursive`
- `python dev_server.py` *(server started then killed)*

------
https://chatgpt.com/codex/tasks/task_e_6866004780d08323bafadbae563e1701