### PR TITLE
Fix S3 etag for binary assets

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -94,7 +94,7 @@ resource "aws_s3_object" "site" {
     lower(element(reverse(split(".", each.key)), 0)),
     "text/plain",
   )
-  etag = md5(each.value.content)
+  etag = each.value.binary ? md5(base64decode(each.value.content)) : md5(each.value.content)
 }
 module "tenant_codebuild" {
   source            = "./modules/codebuild_provisioner"


### PR DESCRIPTION
## Summary
- compute MD5 hash of decoded binary data when generating etags

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate`
- `html5validator --root saas_web`

------
https://chatgpt.com/codex/tasks/task_e_6866d989cf288323a57ca7ea6b960ed5