### PR TITLE
Add DynamoDB caching to cost report

### DIFF
--- a/docs/saas_setup.md
+++ b/docs/saas_setup.md
@@ -54,11 +54,12 @@ stores any tenant-specific API configuration.
 
 ## Cost Reporting Lambda
 
-Each tenant account also includes a simple `cost_report` Lambda function that is
-exposed through an API Gateway endpoint. This function queries the AWS Cost
-Explorer API for the current month's charges and returns the total along with a
-breakdown by service. The console calls this endpoint after authenticating the
-user; no manual placeholder replacement is required.
+Each tenant account also includes a `cost_report` Lambda function exposed
+through an API Gateway endpoint. To keep Cost Explorer API calls to a minimum,
+the function stores the latest results in a DynamoDB table. The Lambda checks
+the cache first and only queries Cost Explorer once per day for each tenant.
+The console reads this endpoint after authenticating the user, so no manual
+placeholder replacement is required.
 
 ## Provisioning Pipeline
 

--- a/saas/lambda/cost_report.py
+++ b/saas/lambda/cost_report.py
@@ -1,12 +1,17 @@
 import boto3
 import json
-from datetime import date, timedelta
+import os
+from datetime import date, timedelta, datetime
+from decimal import Decimal
 import logging
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 ce = boto3.client("ce")
+dynamodb = boto3.resource("dynamodb")
+cost_table_name = os.environ.get("COST_TABLE")
+cost_table = dynamodb.Table(cost_table_name) if cost_table_name else None
 
 
 def handler(event, context):
@@ -22,11 +27,34 @@ def handler(event, context):
         logger.error("Missing tenant_id in claims")
         return {"statusCode": 400, "body": json.dumps({"error": "Missing tenant_id"})}
     today = date.today()
-    start = today.replace(day=1).strftime("%Y-%m-%d")
+    start_date = today.replace(day=1)
+    start = start_date.strftime("%Y-%m-%d")
+    month_key = start_date.strftime("%Y-%m")
     # Cost Explorer requires the end date to be strictly after the start date.
     # The end date is exclusive, so use tomorrow's date to include today's cost
     # when the function runs on the first day of the month.
     end = (today + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    if cost_table:
+        try:
+            resp = cost_table.get_item(Key={"tenant_id": tenant_id, "month": month_key})
+            item = resp.get("Item")
+            logger.debug("Cache lookup result: %s", item)
+            if item:
+                last = item.get("last_updated")
+                if last and datetime.fromisoformat(last).date() >= today - timedelta(days=1):
+                    logger.info("Returning cached cost data")
+                    return {
+                        "statusCode": 200,
+                        "body": json.dumps(
+                            {
+                                "total": float(item.get("total", 0)),
+                                "breakdown": {k: float(v) for k, v in item.get("breakdown", {}).items()},
+                            }
+                        ),
+                    }
+        except Exception:
+            logger.exception("Failed to read cost cache")
     try:
         params = {
             "TimePeriod": {"Start": start, "End": end},
@@ -49,12 +77,28 @@ def handler(event, context):
             "body": json.dumps({"error": "Could not retrieve cost"}),
         }
 
+    logger.debug("Cost Explorer response: %s", resp)
+
     result = resp["ResultsByTime"][0]
     total = float(result["Total"]["UnblendedCost"]["Amount"])
     breakdown = {
         g["Keys"][0]: float(g["Metrics"]["UnblendedCost"]["Amount"])
         for g in result.get("Groups", [])
     }
+
+    if cost_table:
+        try:
+            cost_table.put_item(
+                Item={
+                    "tenant_id": tenant_id,
+                    "month": month_key,
+                    "last_updated": today.isoformat(),
+                    "total": Decimal(str(total)),
+                    "breakdown": {k: Decimal(str(v)) for k, v in breakdown.items()},
+                }
+            )
+        except Exception:
+            logger.exception("Failed to store cost cache")
     return {
         "statusCode": 200,
         "body": json.dumps({"total": total, "breakdown": breakdown}),

--- a/saas/main.tf
+++ b/saas/main.tf
@@ -112,6 +112,7 @@ module "tenant_api" {
   allowed_origins     = ["https://${module.frontend_site.cloudfront_domain}"]
   stripe_secret_key   = var.stripe_secret_key
   domain              = var.domain
+  cost_table_name     = var.cost_table_name
 }
 
 
@@ -149,4 +150,8 @@ output "state_bucket" {
 
 output "lock_table" {
   value = module.terraform_backend.table_name
+}
+
+output "cost_table" {
+  value = module.tenant_api.cost_table
 }

--- a/saas/modules/tenant_api/main.tf
+++ b/saas/modules/tenant_api/main.tf
@@ -33,6 +33,11 @@ resource "aws_iam_role_policy" "tenant_permissions" {
         Resource = "*"
       },
       {
+        Effect   = "Allow",
+        Action   = ["dynamodb:GetItem", "dynamodb:PutItem"],
+        Resource = aws_dynamodb_table.cost_cache.arn
+      },
+      {
         Effect = "Allow",
         Action = [
           "codebuild:StartBuild",
@@ -42,6 +47,23 @@ resource "aws_iam_role_policy" "tenant_permissions" {
       }
     ]
   })
+}
+
+resource "aws_dynamodb_table" "cost_cache" {
+  name         = var.cost_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "tenant_id"
+  range_key    = "month"
+
+  attribute {
+    name = "tenant_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "month"
+    type = "S"
+  }
 }
 
 # Lambda packages
@@ -76,6 +98,11 @@ resource "aws_lambda_function" "cost_report" {
   handler          = "cost_report.handler"
   runtime          = "python3.11"
   timeout          = 10
+  environment {
+    variables = {
+      COST_TABLE = aws_dynamodb_table.cost_cache.name
+    }
+  }
 }
 
 data "archive_file" "init_server" {

--- a/saas/modules/tenant_api/outputs.tf
+++ b/saas/modules/tenant_api/outputs.tf
@@ -1,3 +1,7 @@
 output "api_url" {
   value = aws_apigatewayv2_stage.prod.invoke_url
 }
+
+output "cost_table" {
+  value = aws_dynamodb_table.cost_cache.name
+}

--- a/saas/modules/tenant_api/variables.tf
+++ b/saas/modules/tenant_api/variables.tf
@@ -31,3 +31,8 @@ variable "domain" {
   description = "Public domain for success/cancel URLs"
   type        = string
 }
+
+variable "cost_table_name" {
+  description = "DynamoDB table name for cached cost data"
+  type        = string
+}

--- a/saas/variables.tf
+++ b/saas/variables.tf
@@ -68,3 +68,9 @@ variable "lock_table_name" {
   type        = string
   default     = "terraform-locks"
 }
+
+variable "cost_table_name" {
+  description = "DynamoDB table name for cached cost reports"
+  type        = string
+  default     = "minecraft-cost-cache"
+}


### PR DESCRIPTION
## Summary
- cache cost explorer results in DynamoDB
- wire table into tenant API module
- expose cost table name from root module
- add debug logging for troubleshooting
- document the caching behavior

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=saas init -backend=false`
- `terraform -chdir=saas validate`
- `html5validator --root saas_web`
- `python dev_server.py` (manual startup check)

------
https://chatgpt.com/codex/tasks/task_e_6866cb1282f88323a8bdd6ee86490acc