### PR TITLE
Consolidate error handling

### DIFF
--- a/saas_web/404.html
+++ b/saas_web/404.html
@@ -1,47 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <link rel="icon" type="image/png" href="/favicon.ico" />
-  <title>Page Not Found - Minecraft for All</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    html, body {
-      margin: 0;
-      height: 100%;
-      background: linear-gradient(135deg, #0d0d0d, #1a1a2e);
-      color: #ffffff;
-      font-family: 'Roboto', sans-serif;
-    }
-    #container {
-      min-height: 100%;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
-    a { color: #81d4fa; }
-    h1 { color: #b39ddb; }
-    .block-buddy {
-      width: 128px;
-      height: 128px;
-      background-image: url('assets/emerald_block_buddies.png');
-      background-size: 256px 256px;
-      background-position: 0 -128px;
-      image-rendering: pixelated;
-      margin-bottom: 1rem;
-    }
-  </style>
+  <meta http-equiv="refresh" content="0; url=/404" />
+  <title>Redirecting...</title>
 </head>
 <body>
-  <div id="container">
-    <div class="block-buddy"></div>
-    <i class="fas fa-question-circle fa-3x" style="margin-bottom: 1rem;"></i>
-    <BlockBuddy sheet="iron" :index="3" />
-    <h1>404 - Page Not Found</h1>
-    <p><a href="/">Return Home</a></p>
-  </div>
+  <p>Redirecting...</p>
 </body>
 </html>

--- a/saas_web/50x.html
+++ b/saas_web/50x.html
@@ -1,46 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <link rel="icon" type="image/png" href="/favicon.ico" />
-  <title>Error - Minecraft for All</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    html, body {
-      margin: 0;
-      height: 100%;
-      background: linear-gradient(135deg, #0d0d0d, #1a1a2e);
-      color: #ffffff;
-      font-family: 'Roboto', sans-serif;
-    }
-    #container {
-      min-height: 100%;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
-    a { color: #81d4fa; }
-    h1 { color: #b39ddb; }
-    .block-buddy {
-      width: 128px;
-      height: 128px;
-      background-image: url('assets/iron_ore_buddies.png');
-      background-size: 256px 256px;
-      background-position: -128px -128px;
-      image-rendering: pixelated;
-      margin-bottom: 1rem;
-    }
-  </style>
+  <meta http-equiv="refresh" content="0; url=/error" />
+  <title>Redirecting...</title>
 </head>
 <body>
-  <div id="container">
-    <div class="block-buddy"></div>
-    <i class="fas fa-exclamation-triangle fa-3x" style="margin-bottom: 1rem;"></i>
-    <h1>Oops! Something went wrong.</h1>
-    <p>Please try again later. <a href="/">Return Home</a></p>
-  </div>
+  <p>Redirecting...</p>
 </body>
 </html>

--- a/saas_web/components/ErrorPage.vue
+++ b/saas_web/components/ErrorPage.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-container class="text-center">
+    <i :class="`${icon} fa-3x mb-4`"></i>
+    <BlockBuddy :sheet="buddySheet" :index="buddyIndex" />
+    <h1>{{ title }}</h1>
+    <slot>
+      <p><a href="/">Return Home</a></p>
+    </slot>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'ErrorPage',
+  props: {
+    title: { type: String, default: 'Error' },
+    icon: { type: String, default: 'fas fa-exclamation-triangle' },
+    buddySheet: { type: String, default: 'emerald' },
+    buddyIndex: { type: Number, default: 0 },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/saas_web/components/NotFound.vue
+++ b/saas_web/components/NotFound.vue
@@ -1,15 +1,17 @@
 <template>
-  <v-container class="text-center">
-    <i class="fas fa-question-circle fa-3x mb-4"></i>
-    <BlockBuddy sheet="iron" :index="3" />
-    <h1>404 - Page Not Found</h1>
-    <p><a href="/">Return Home</a></p>
-  </v-container>
+  <ErrorPage
+    title="404 - Page Not Found"
+    icon="fas fa-question-circle"
+    buddy-sheet="iron"
+    :buddy-index="3"
+  />
 </template>
 
 <script>
+import ErrorPage from './ErrorPage.vue';
 export default {
   name: 'NotFound',
+  components: { ErrorPage },
 };
 </script>
 

--- a/saas_web/components/ServerError.vue
+++ b/saas_web/components/ServerError.vue
@@ -1,0 +1,21 @@
+<template>
+  <ErrorPage
+    title="Oops! Something went wrong."
+    icon="fas fa-exclamation-triangle"
+    buddy-sheet="iron"
+    :buddy-index="1"
+  >
+    <p>Please try again later. <a href="/">Return Home</a></p>
+  </ErrorPage>
+</template>
+
+<script>
+import ErrorPage from './ErrorPage.vue';
+export default {
+  name: 'ServerError',
+  components: { ErrorPage },
+};
+</script>
+
+<style scoped>
+</style>

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -37,6 +37,8 @@ window.componentsPath = './components';
       { path: '/login', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Login.vue`, options) },
       { path: '/console', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Console.vue`, options) },
       { path: '/start', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/Start.vue`, options) },
+      { path: '/404', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/NotFound.vue`, options) },
+      { path: '/error', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/ServerError.vue`, options) },
       // Debug routes to view individual steps without the wizard
       { path: '/debug-payment', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/start/StepPayment.vue`, options) },
       { path: '/debug-config', component: () => window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/start/StepConfig.vue`, options) },


### PR DESCRIPTION
## Summary
- add a reusable `ErrorPage` component
- build `NotFound` and `ServerError` from `ErrorPage`
- add routes for `/404` and `/error`
- change static 404 and 50x pages to redirect to the Vue routes

## Testing
- `~/.local/bin/html5validator --root saas_web`
- `terraform fmt -recursive`
- `python dev_server.py` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_6866db5aa5e08323a6047db561caacf6