### PR TITLE
Fix terraform dynamodb ttl attribute error

### DIFF
--- a/saas/modules/tenant_api/main.tf
+++ b/saas/modules/tenant_api/main.tf
@@ -65,11 +65,6 @@ resource "aws_dynamodb_table" "cost_cache" {
     type = "S"
   }
 
-  attribute {
-    name = "expires_at"
-    type = "N"
-  }
-
   ttl {
     attribute_name = "expires_at"
     enabled        = true


### PR DESCRIPTION
## Summary
- remove unused `expires_at` attribute from DynamoDB cost_cache table

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `terraform fmt -recursive`
- `html5validator --root saas_web`

------
https://chatgpt.com/codex/tasks/task_e_6866e49915808323965073867f330f7b