### PR TITLE
Update site colors with pixel themed look

### DIFF
--- a/saas_web/components/start/StepIndicator.vue
+++ b/saas_web/components/start/StepIndicator.vue
@@ -35,25 +35,26 @@ export default {
   align-items: center;
 }
 .step-circle {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  border-radius: 2px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 500;
-  color: white;
-  background-color: #603652;
+  font-weight: 700;
+  font-family: 'Press Start 2P', cursive;
+  color: #fff;
+  background-color: #4caf50;
 }
 
 .step-circle.active {
-  border: 2px solid white;
-  background-color: transparent;
+  border: 2px solid #ffa500;
+  background-color: #262626;
 }
 
 .step-line {
   width: 40px;
-  height: 2px;
-  background-color: #603652;
+  height: 4px;
+  background-color: #4caf50;
 }
 </style>

--- a/saas_web/index.html
+++ b/saas_web/index.html
@@ -6,7 +6,8 @@
   <title>Minecraft for All</title>
   <base href="/" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.css" integrity="sha384-ZoPVozdjzH+jWXpaBM47rBZy9ofMIg8tuIIAsAf5YgJ0wYs5XzytOpaLxiu93Off" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     html, body, #app {
@@ -18,16 +19,19 @@
     body {
       background: linear-gradient(
         135deg,
-        #2d003d,
-        #000b63,
+        #113924,
+        #0c1e36,
         #000000
       );
-      color: #ffffff;
+      color: #e0e0e0;
       font-family: 'Roboto', sans-serif;
     }
-  
-      a { color: #89cff0; }
-      h1, h2, h3, h4, h5, h6 { color: #ffb6c1; }
+
+      a { color: #4caf50; }
+      h1, h2, h3, h4, h5, h6 {
+        color: #ffa500;
+        font-family: 'Press Start 2P', cursive;
+      }
   </style>  
 </head>
 <body>

--- a/saas_web/main.js
+++ b/saas_web/main.js
@@ -53,9 +53,9 @@ window.componentsPath = './components';
           dark: {
             colors: {
               background: '#000000',
-              surface: '#1a1a2e',
-              primary: '#89cff0',
-              secondary: '#ffb6c1',
+              surface: '#262626',
+              primary: '#4caf50',
+              secondary: '#ffa500',
             },
           },
       },


### PR DESCRIPTION
## Summary
- brighten background colors and font choices
- add blocky step indicator style
- swap vuetify theme to green/orange palette

## Testing
- `html5validator --root saas_web`
- `terraform fmt -recursive`
- `python dev_server.py` (launches server)


------
https://chatgpt.com/codex/tasks/task_e_6866fea13afc832388471231f44e6b63