### PR TITLE
Add speech bubble feature

### DIFF
--- a/saas_web/components/BlockBuddy.vue
+++ b/saas_web/components/BlockBuddy.vue
@@ -1,25 +1,31 @@
 <template>
-  <div class="block-buddy" :style="style" aria-hidden="true"></div>
+  <div class="block-buddy-wrapper">
+    <div v-if="message" class="speech-bubble" role="status" aria-live="polite">
+      {{ message }}
+    </div>
+    <div class="block-buddy" :style="style" aria-hidden="true"></div>
+  </div>
 </template>
 
 <script>
 export default {
-  name: 'BlockBuddy',
+  name: "BlockBuddy",
   props: {
-    sheet: { type: String, default: 'emerald' },
+    sheet: { type: String, default: "emerald" },
     index: { type: Number, default: 0 },
     size: { type: Number, default: 128 },
+    message: { type: String, default: "" },
   },
   computed: {
     style() {
       const sheets = {
-        emerald: 'assets/emerald_block_buddies.png',
-        iron: 'assets/iron_ore_buddies.png',
+        emerald: "assets/emerald_block_buddies.png",
+        iron: "assets/iron_ore_buddies.png",
       };
       const size = this.size;
       const sheetSize = size * 2;
       const positions = [
-        '0px 0px',
+        "0px 0px",
         `-${size}px 0px`,
         `0px -${size}px`,
         `-${size}px -${size}px`,
@@ -27,10 +33,10 @@ export default {
       return {
         width: `${size}px`,
         height: `${size}px`,
-        'background-image': `url(${sheets[this.sheet] || sheets.emerald})`,
-        'background-size': `${sheetSize}px ${sheetSize}px`,
-        'background-position': positions[this.index % 4],
-        'image-rendering': 'pixelated',
+        "background-image": `url(${sheets[this.sheet] || sheets.emerald})`,
+        "background-size": `${sheetSize}px ${sheetSize}px`,
+        "background-position": positions[this.index % 4],
+        "image-rendering": "pixelated",
       };
     },
   },
@@ -38,7 +44,36 @@ export default {
 </script>
 
 <style scoped>
+.block-buddy-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .block-buddy {
   display: inline-block;
+}
+
+.speech-bubble {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  border: 2px solid #000;
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: #000;
+  white-space: nowrap;
+  font-size: 0.75rem;
+}
+
+.speech-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: #fff;
 }
 </style>

--- a/saas_web/components/Home.vue
+++ b/saas_web/components/Home.vue
@@ -4,50 +4,78 @@
       <!-- Segment 1 -->
       <v-row class="py-16 segment" align="center">
         <v-col cols="12" md="6">
-          <h2 class="text-h4 mb-4">The ONLY pure usage-based pricing available</h2>
-          <p>We are the only Minecraft server hosting service that has NO FLAT MONTHLY RATES. If you don't use our services for the month, you'll pay $0!</p>
+          <h2 class="text-h4 mb-4">
+            The ONLY pure usage-based pricing available
+          </h2>
+          <p>
+            We are the only Minecraft server hosting service that has NO FLAT
+            MONTHLY RATES. If you don't use our services for the month, you'll
+            pay $0!
+          </p>
         </v-col>
         <v-col cols="12" md="6" class="text-center">
-          <BlockBuddy sheet="iron" :index="0" :size="192" />
+          <BlockBuddy
+            sheet="iron"
+            :index="0"
+            :size="192"
+            message="No monthly rates!"
+          />
         </v-col>
       </v-row>
 
       <!-- Segment 2 -->
       <v-row class="py-16 segment" align="center">
         <v-col cols="12" md="6" class="text-center order-md-first order-last">
-          <BlockBuddy sheet="emerald" :index="1" :size="192" />
+          <BlockBuddy
+            sheet="emerald"
+            :index="1"
+            :size="192"
+            message="Transparent usage!"
+          />
         </v-col>
         <v-col cols="12" md="6">
           <h2 class="text-h4 mb-4">Transparent pricing</h2>
-          <p>You can track your usage of <i>compute</i>, <i>storage</i>, and <i>network bandwidth</i> in the Console.</p>
+          <p>
+            You can track your usage of <i>compute</i>, <i>storage</i>, and
+            <i>network bandwidth</i> in the Console.
+          </p>
         </v-col>
       </v-row>
 
       <!-- Segment 3 -->
       <v-row class="py-16 segment" align="center" justify="center">
         <v-col cols="12" class="text-center">
-          <v-btn color="primary" size="x-large" to="/start">
-            Start
-          </v-btn>
+          <v-btn color="primary" size="x-large" to="/start"> Start </v-btn>
         </v-col>
       </v-row>
 
       <!-- Segment 4 -->
       <v-row class="py-16 segment" align="center">
         <v-col cols="12" md="6" class="text-center">
-          <BlockBuddy sheet="diamond" :index="2" :size="192" />
+          <BlockBuddy
+            sheet="diamond"
+            :index="2"
+            :size="192"
+            message="Control your server!"
+          />
         </v-col>
         <v-col cols="12" md="6">
           <h2 class="text-h4 mb-4">Complete control</h2>
-          <p>You are given complete control over the </p>
+          <p>You are given complete control over the</p>
         </v-col>
       </v-row>
 
       <!-- Segment 5 -->
       <v-row class="py-16 segment" align="center">
         <v-col cols="12" md="6">
-          <h2 class="text-h4 mb-4">Enterprise-level features for peace of mind</h2>
-          <p>We provide all the "enterprise-level" features you'll see from other hosters such as automatic backups, DDoS protection, and more. Plus we've decoded what they even mean:</p>
+          <h2 class="text-h4 mb-4">
+            Enterprise-level features for peace of mind
+          </h2>
+          <p>
+            We provide all the "enterprise-level" features you'll see from other
+            hosters such as automatic backups, DDoS protection, and more. Plus
+            we've decoded what they even mean:
+          </p>
         </v-col>
         <v-col cols="12" md="6" class="text-center">
           <v-list class="text-left">
@@ -55,7 +83,11 @@
               <v-list-item-content>
                 <div>
                   <h3>Automatic backups</h3>
-                  <p>We automatically backup your server to our storage with industry leading availability and durability (99.999999999%).</p>
+                  <p>
+                    We automatically backup your server to our storage with
+                    industry leading availability and durability
+                    (99.999999999%).
+                  </p>
                 </div>
               </v-list-item-content>
             </v-list-item>
@@ -63,7 +95,10 @@
               <v-list-item-content>
                 <div>
                   <h3>DDoS protection</h3>
-                  <p>Protection against a wide range of known attacks is standard with every server you can use with us.</p>
+                  <p>
+                    Protection against a wide range of known attacks is standard
+                    with every server you can use with us.
+                  </p>
                 </div>
               </v-list-item-content>
             </v-list-item>
@@ -71,7 +106,10 @@
               <v-list-item-content>
                 <div>
                   <h3>Resource analytics</h3>
-                  <p>Dive deep on your resource usage to optimize costs for your players. It's what we're built for!</p>
+                  <p>
+                    Dive deep on your resource usage to optimize costs for your
+                    players. It's what we're built for!
+                  </p>
                 </div>
               </v-list-item-content>
             </v-list-item>
@@ -84,10 +122,13 @@
 
 <script>
 export default {
-  name: 'Home',
+  name: "Home",
   components: {
     BlockBuddy: Vue.defineAsyncComponent(() =>
-      window['vue3-sfc-loader'].loadModule(`${window.componentsPath}/BlockBuddy.vue`, window.loaderOptions)
+      window["vue3-sfc-loader"].loadModule(
+        `${window.componentsPath}/BlockBuddy.vue`,
+        window.loaderOptions,
+      ),
     ),
   },
 };


### PR DESCRIPTION
## Summary
- add `message` prop and bubble layout to `BlockBuddy`
- surface BlockBuddy speech bubbles on the home page

## Testing
- `npx prettier -w saas_web/components/BlockBuddy.vue saas_web/components/Home.vue`
- `npx eslint --fix saas_web/components/BlockBuddy.vue saas_web/components/Home.vue` *(fails: ESLint couldn't find a config)*
- `html5validator --root saas_web`
- `terraform fmt -recursive`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68686763b16083238c3a0be3fc1374cf