### PR TITLE
Allow gradient or image background for BlockBuddy

### DIFF
--- a/saas_web/components/App.vue
+++ b/saas_web/components/App.vue
@@ -11,7 +11,7 @@
           text-decoration: none;
         "
       >
-        <BlockBuddy sheet="iron" :index="0" :size="64" with-background />
+        <BlockBuddy sheet="iron" :index="0" :size="64" background="gradient" />
       </router-link>
       <v-spacer></v-spacer>
       <div class="d-none d-md-flex align-center">

--- a/saas_web/components/BlockBuddy.vue
+++ b/saas_web/components/BlockBuddy.vue
@@ -59,6 +59,7 @@ export default {
         height: size,
         "background-image": `url(${path})`,
         "background-size": "cover",
+        "border-radius": "50%",
       };
     },
   },

--- a/saas_web/components/BlockBuddy.vue
+++ b/saas_web/components/BlockBuddy.vue
@@ -1,6 +1,5 @@
 <template>
-  <div :class="wrapperClass">
-    <div v-if="background" class="bg-image" aria-hidden="true"></div>
+  <div class="block-buddy-wrapper" :style="wrapperStyle">
     <div v-if="message" class="speech-bubble" role="status" aria-live="polite">
       {{ message }}
     </div>
@@ -15,9 +14,8 @@ export default {
     sheet: { type: String, default: "emerald" },
     index: { type: Number, default: 0 },
     size: { type: Number, default: 128 },
-    background: { type: Boolean, default: false },
+    background: { type: String, default: "" },
     message: { type: String, default: "" },
-    withBackground: { type: Boolean, default: false },
   },
   computed: {
     style() {
@@ -42,10 +40,25 @@ export default {
         "image-rendering": "pixelated",
       };
     },
-    wrapperClass() {
+    wrapperStyle() {
+      if (!this.background) return {};
+      const size = `${this.size}px`;
+      if (this.background === "gradient") {
+        return {
+          width: size,
+          height: size,
+          background:
+            "radial-gradient(circle, rgba(240,229,196,0.8), rgba(240,229,196,0) 70%)",
+          "border-radius": "50%",
+        };
+      }
+      let path = this.background;
+      if (!path.startsWith("assets/")) path = `assets/${path}`;
       return {
-        "block-buddy-wrapper": true,
-        background: this.background,
+        width: size,
+        height: size,
+        "background-image": `url(${path})`,
+        "background-size": "cover",
       };
     },
   },
@@ -56,34 +69,6 @@ export default {
 .block-buddy-wrapper {
   position: relative;
   display: inline-block;
-}
-
-.block-buddy-wrapper.background {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: 0;
-}
-
-.bg-image {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-image: url("assets/background.png");
-  background-size: cover;
-}
-
-.block-buddy-wrapper.background .block-buddy {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
 }
 
 .block-buddy {

--- a/saas_web/components/ErrorPage.vue
+++ b/saas_web/components/ErrorPage.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="text-center">
     <i :class="`${icon} fa-3x mb-4`"></i>
-    <BlockBuddy :sheet="buddySheet" :index="buddyIndex" with-background />
+    <BlockBuddy :sheet="buddySheet" :index="buddyIndex" background="gradient" />
     <h1>{{ title }}</h1>
     <slot>
       <p><a href="/">Return Home</a></p>

--- a/saas_web/components/Home.vue
+++ b/saas_web/components/Home.vue
@@ -19,7 +19,7 @@
             :index="0"
             :size="192"
             message="No minimums!"
-            with-background
+            background="gradient"
           />
         </v-col>
       </v-row>
@@ -53,7 +53,7 @@
             :index="2"
             :size="192"
             message="Control your server!"
-            with-background
+            background="gradient"
           />
         </v-col>
         <v-col cols="12" md="6">

--- a/saas_web/components/Support.vue
+++ b/saas_web/components/Support.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row class="justify-center mb-4">
-      <BlockBuddy sheet="iron" :index="1" with-background />
+      <BlockBuddy sheet="iron" :index="1" background="gradient" />
     </v-row>
     <v-row>
       <v-col>


### PR DESCRIPTION
## Summary
- clean up BlockBuddy component
- allow `background="gradient"` or image path
- update usage across Vue components

## Testing
- `npx prettier -w saas_web/components/BlockBuddy.vue saas_web/components/App.vue saas_web/components/Support.vue saas_web/components/ErrorPage.vue saas_web/components/Home.vue`
- `npx eslint saas_web/components/BlockBuddy.vue` *(fails: ESLint couldn't find a config)*
- `html5validator --root saas_web` *(fails: command not found)*
- `terraform fmt -recursive` *(fails: command not found)*
- `python dev_server.py` *(manual check)*
- `pytest -q` *(fails: ModuleNotFoundError: playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6869c9b0a3fc832386af29c3edf735b4