### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ to `terraform.tfvars` and fill in your values before running `terraform apply`.
 The `tenant_id` variable is required but normally passed in automatically by
 the provisioning pipeline.
 
+### Development Setup
+
+Run the `scripts/setup_dev.sh` script to install the tools used for
+linting and validation. It installs Terraform, Prettier, ESLint and the
+Python utilities required by the test suite.
+
+```bash
+./scripts/setup_dev.sh
+```
+
 ## Testing
 
 Basic checks run automatically via GitHub Actions whenever you push changes.

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Setup development dependencies for minecraft_for_all
+# This installs tools used by the repository's lint and test
+# workflows: Terraform, Node.js tooling and Python packages.
+set -euo pipefail
+
+# Update apt and install base packages
+sudo apt-get update
+sudo apt-get install -y curl gnupg unzip python3-pip nodejs npm
+
+# Install Terraform from HashiCorp apt repository if not already installed
+if ! command -v terraform >/dev/null 2>&1; then
+  curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+  sudo apt-get update
+  sudo apt-get install -y terraform
+fi
+
+# Install global Node tools used for formatting and linting
+sudo npm install -g prettier eslint
+
+# Install Python packages used in tests and validation
+python3 -m pip install --upgrade pip
+python3 -m pip install html5validator playwright
+
+# Install Playwright browsers
+playwright install --with-deps
+
+cat <<MSG
+Development tools installed:
+  - terraform $(terraform version | head -n1)
+  - node $(node --version)
+  - npm $(npm --version)
+  - prettier $(prettier --version)
+  - eslint $(eslint --version)
+  - html5validator $(python3 -m pip show html5validator | grep Version)
+MSG

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -33,5 +33,5 @@ Development tools installed:
   - npm $(npm --version)
   - prettier $(prettier --version)
   - eslint $(eslint --version)
-  - html5validator $(python3 -m pip show html5validator | grep Version)
+  - html5validator $(python3 -m pip show html5validator | grep Version | awk '{print $2}')
 MSG


### PR DESCRIPTION
## Summary
- add `scripts/setup_dev.sh` to quickly install Terraform, Prettier and other tools
- document usage of the setup script in README

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`

------
https://chatgpt.com/codex/tasks/task_e_6869ce9673088323860ccb411f61c536