### PR TITLE
Fix BlockBuddy background sizing

### DIFF
--- a/saas_web/components/BlockBuddy.vue
+++ b/saas_web/components/BlockBuddy.vue
@@ -59,7 +59,8 @@ export default {
         width: size,
         height: size,
         "background-image": `url(${path})`,
-        "background-size": "cover",
+        "background-repeat": "no-repeat",
+        "background-size": "100% 100%",
         "border-radius": "50%",
       };
     },


### PR DESCRIPTION
## Summary
- tweak BlockBuddy wrapper background style so image backgrounds are not tiled
- run repo linters & validators

## Testing
- `npx prettier --write saas_web/components/BlockBuddy.vue`
- `eslint saas_web/components/BlockBuddy.vue` *(fails: couldn't find config)*
- `html5validator --root saas_web`
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6869d3a0d3488323ac61f06ccc46e3b9