### PR TITLE
Fix codebuild provisioner region and account id

### DIFF
--- a/saas/main.tf
+++ b/saas/main.tf
@@ -103,6 +103,7 @@ module "tenant_codebuild" {
   state_bucket_name = module.terraform_backend.bucket_name
   lock_table_name   = module.terraform_backend.table_name
   server_table_name = var.server_table_name
+  region            = var.region
 }
 
 module "tenant_api" {

--- a/saas/modules/codebuild_provisioner/main.tf
+++ b/saas/modules/codebuild_provisioner/main.tf
@@ -11,6 +11,8 @@ resource "aws_iam_role" "codebuild" {
   })
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_role_policy" "terraform" {
   name = "minecraft-codebuild-terraform-policy"
   role = aws_iam_role.codebuild.id
@@ -32,7 +34,7 @@ resource "aws_iam_role_policy" "terraform" {
         "dynamodb:GetItem"
       ]
       Resource = [
-        "arn:aws:dynamodb:${var.aws_region}:${var.aws_account_id}:table/${var.server_table_name}"
+        "arn:aws:dynamodb:${var.region}:${data.aws_caller_identity.current.account_id}:table/${var.server_table_name}"
       ]
     }]
   })

--- a/saas/modules/codebuild_provisioner/variables.tf
+++ b/saas/modules/codebuild_provisioner/variables.tf
@@ -28,3 +28,8 @@ variable "server_table_name" {
   description = "DynamoDB table tracking tenant servers"
   type        = string
 }
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- declare `aws_region` and `aws_account_id` implicitly for the CodeBuild policy
- use data sources to populate the DynamoDB ARN

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_686d43ca7ff08323840a7c025d4f4c45