### PR TITLE
Add EC2/EBS metrics endpoint

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -74,6 +74,13 @@ if __name__ == "__main__":
             ("GET", "/MC_API/status"): (200, {"state": "offline", "exists": False}),
             ("POST", "/MC_API/start"): (200, None),
             ("GET", "/MC_API/cost"): (200, {"total": 0}),
+            (
+                "GET",
+                "/MC_API/metrics",
+            ): (
+                200,
+                {"network_in": 0, "network_out": 0, "volumes": []},
+            ),
             ("POST", "/MC_API/checkout"): (200, {"client_secret": "seti_dummy"}),
             ("POST", "/MC_API/delete"): (200, None),
         }

--- a/saas/lambda/resource_metrics.py
+++ b/saas/lambda/resource_metrics.py
@@ -1,0 +1,134 @@
+import json
+import logging
+from datetime import datetime, timedelta
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ec2 = boto3.client("ec2")
+cloudwatch = boto3.client("cloudwatch")
+
+
+def get_sum(metric):
+    datapoints = metric.get("Datapoints", [])
+    if not datapoints:
+        return 0.0
+    # return most recent datapoint
+    return sorted(datapoints, key=lambda d: d["Timestamp"], reverse=True)[0].get("Sum", 0.0)
+
+
+def handler(event, context):
+    """Return basic EC2 and EBS metrics for the tenant's server."""
+    claims = (
+        event.get("requestContext", {})
+        .get("authorizer", {})
+        .get("jwt", {})
+        .get("claims", {})
+    )
+    tenant_id = claims.get("custom:tenant_id")
+    if not tenant_id:
+        return {"statusCode": 400, "body": json.dumps({"error": "missing tenant_id"})}
+
+    params = event.get("queryStringParameters") or {}
+    server_id = params.get("server_id", "1")
+
+    try:
+        resp = ec2.describe_instances(
+            Filters=[
+                {"Name": "tag:tenant_id", "Values": [tenant_id]},
+                {"Name": "tag:server_id", "Values": [server_id]},
+            ]
+        )
+    except Exception:
+        logger.exception("Failed to describe instances")
+        return {"statusCode": 500, "body": json.dumps({"error": "failed to query"})}
+
+    reservations = resp.get("Reservations", [])
+    if not reservations:
+        return {"statusCode": 404, "body": json.dumps({"error": "instance not found"})}
+
+    instance = reservations[0]["Instances"][0]
+    instance_id = instance["InstanceId"]
+
+    now = datetime.utcnow()
+    start = now - timedelta(hours=1)
+
+    try:
+        net_in = cloudwatch.get_metric_statistics(
+            Namespace="AWS/EC2",
+            MetricName="NetworkIn",
+            Dimensions=[{"Name": "InstanceId", "Value": instance_id}],
+            StartTime=start,
+            EndTime=now,
+            Period=3600,
+            Statistics=["Sum"],
+        )
+        net_out = cloudwatch.get_metric_statistics(
+            Namespace="AWS/EC2",
+            MetricName="NetworkOut",
+            Dimensions=[{"Name": "InstanceId", "Value": instance_id}],
+            StartTime=start,
+            EndTime=now,
+            Period=3600,
+            Statistics=["Sum"],
+        )
+        network_in = get_sum(net_in)
+        network_out = get_sum(net_out)
+    except Exception:
+        logger.exception("Failed to get network metrics")
+        network_in = 0.0
+        network_out = 0.0
+
+    try:
+        vols = ec2.describe_volumes(
+            Filters=[
+                {"Name": "tag:tenant_id", "Values": [tenant_id]},
+                {"Name": "tag:server_id", "Values": [server_id]},
+            ]
+        )
+    except Exception:
+        logger.exception("Failed to describe volumes")
+        return {"statusCode": 500, "body": json.dumps({"error": "failed to query volumes"})}
+
+    volumes = []
+    for v in vols.get("Volumes", []):
+        vol_id = v["VolumeId"]
+        size_gb = v.get("Size")
+        try:
+            read = cloudwatch.get_metric_statistics(
+                Namespace="AWS/EBS",
+                MetricName="VolumeReadBytes",
+                Dimensions=[{"Name": "VolumeId", "Value": vol_id}],
+                StartTime=start,
+                EndTime=now,
+                Period=3600,
+                Statistics=["Sum"],
+            )
+            write = cloudwatch.get_metric_statistics(
+                Namespace="AWS/EBS",
+                MetricName="VolumeWriteBytes",
+                Dimensions=[{"Name": "VolumeId", "Value": vol_id}],
+                StartTime=start,
+                EndTime=now,
+                Period=3600,
+                Statistics=["Sum"],
+            )
+            read_bytes = get_sum(read)
+            write_bytes = get_sum(write)
+        except Exception:
+            logger.exception("Failed to get volume metrics")
+            read_bytes = 0.0
+            write_bytes = 0.0
+        volumes.append(
+            {
+                "id": vol_id,
+                "size_gb": size_gb,
+                "read_bytes": read_bytes,
+                "write_bytes": write_bytes,
+            }
+        )
+
+    body = {"network_in": network_in, "network_out": network_out, "volumes": volumes}
+    return {"statusCode": 200, "body": json.dumps(body)}

--- a/saas_web/components/console/DataView.vue
+++ b/saas_web/components/console/DataView.vue
@@ -1,13 +1,89 @@
 <template>
   <div>
-    <h3 class="text-h6 mb-2">Storage Metrics</h3>
-    <p>EBS usage and volume management tools will appear here.</p>
+    <h3 class="text-h6 mb-2">Server Metrics</h3>
+    <v-container v-if="loading" class="d-flex justify-center">
+      <v-progress-circular indeterminate></v-progress-circular>
+    </v-container>
+    <div v-else>
+      <p>Network In (last hour): {{ formatBytes(metrics.network_in) }}</p>
+      <p>Network Out (last hour): {{ formatBytes(metrics.network_out) }}</p>
+      <h4 class="text-h6 mt-4 mb-2">EBS Volumes</h4>
+      <v-table density="compact" class="mb-4">
+        <thead>
+          <tr>
+            <th class="text-left">ID</th>
+            <th class="text-left">Size (GiB)</th>
+            <th class="text-left">Read</th>
+            <th class="text-left">Write</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="vol in metrics.volumes" :key="vol.id">
+            <td>{{ vol.id }}</td>
+            <td>{{ vol.size_gb }}</td>
+            <td>{{ formatBytes(vol.read_bytes) }}</td>
+            <td>{{ formatBytes(vol.write_bytes) }}</td>
+          </tr>
+        </tbody>
+      </v-table>
+    </div>
   </div>
 </template>
 
 <script>
+const { Auth } = aws_amplify;
 export default {
   name: "DataView",
+  data() {
+    return {
+      loading: true,
+      metrics: { network_in: 0, network_out: 0, volumes: [] },
+      apiUrl: "MC_API_URL",
+    };
+  },
+  methods: {
+    async authHeader() {
+      try {
+        const session = await Auth.currentSession();
+        const token = session.getIdToken().getJwtToken();
+        return { Authorization: `Bearer ${token}` };
+      } catch (err) {
+        console.error("No auth token", err);
+        return {};
+      }
+    },
+    endpoint(path) {
+      const normalizedApiUrl = this.apiUrl.replace(/\/+$/, "");
+      return `${normalizedApiUrl}/${path}`;
+    },
+    async fetchMetrics() {
+      try {
+        const res = await fetch(this.endpoint("metrics"), {
+          headers: await this.authHeader(),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        this.metrics = data;
+      } catch (err) {
+        console.error(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+    formatBytes(v) {
+      let value = v;
+      const units = ["B", "KB", "MB", "GB", "TB"];
+      let i = 0;
+      while (value >= 1024 && i < units.length - 1) {
+        value /= 1024;
+        i += 1;
+      }
+      return `${value.toFixed(1)} ${units[i]}`;
+    },
+  },
+  mounted() {
+    this.fetchMetrics();
+  },
 };
 </script>
 


### PR DESCRIPTION
## Summary
- add `resource_metrics` Lambda to return EC2 and EBS stats
- expose new Lambda via API Gateway in `tenant_api` module
- show server metrics on console page
- mock new endpoint in development server

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=saas init`
- `terraform -chdir=saas validate` *(fails: undeclared variables)*
- `html5validator --root saas_web`
- `npx eslint saas_web/components/console/DataView.vue` *(fails: missing config)*
- `pytest -q` *(fails: ModuleNotFoundError: 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_686d44c682d48323b7397d9a6da4a912