### PR TITLE
Add new server creation tab

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -79,6 +79,7 @@ if __name__ == "__main__":
             ): (
                 200,
                 {"network_in": 0, "network_out": 0, "volumes": []},
+            ),
             (
                 "GET",
                 "/MC_API/cost",

--- a/saas_web/components/Console.vue
+++ b/saas_web/components/Console.vue
@@ -11,6 +11,9 @@
       >
         <v-btn>{{ server }}</v-btn>
       </v-slide-group-item>
+      <v-slide-group-item value="new">
+        <v-btn color="secondary">+ New Server</v-btn>
+      </v-slide-group-item>
     </v-slide-group>
     <v-row>
       <v-col cols="12" md="3">
@@ -27,27 +30,29 @@
       </v-col>
       <v-col cols="12" md="9">
         <template v-if="menu === 'server'">
-          <h2 class="text-h5 mb-4">Server Console</h2>
-          <div>{{ status }}</div>
-          <div class="mt-2">{{ costMessage }}</div>
-          <div v-if="progress" class="mt-2">{{ progress }}</div>
-          <v-btn v-if="showStart" @click="start" class="mt-2"
-            >Start Server</v-btn
-          >
-          <v-btn
-            v-if="serverExists"
-            :disabled="deleting"
-            @click="deleteStack"
-            class="mt-2"
-            color="error"
-          >
-            <span v-if="!deleting">Delete Server</span>
-            <span v-else>Deleting...</span>
-          </v-btn>
-          <h3 v-if="!serverExists" class="text-h6 mt-8 mb-2">
-            Start a New Server
-          </h3>
-          <StepConfig v-if="!serverExists" @complete="handleInitComplete" />
+          <template v-if="selectedServer === 'new'">
+            <h2 class="text-h5 mb-4">Start a New Server</h2>
+            <StepConfig @complete="handleInitComplete" />
+          </template>
+          <template v-else>
+            <h2 class="text-h5 mb-4">Server Console</h2>
+            <div>{{ status }}</div>
+            <div class="mt-2">{{ costMessage }}</div>
+            <div v-if="progress" class="mt-2">{{ progress }}</div>
+            <v-btn v-if="showStart" @click="start" class="mt-2"
+              >Start Server</v-btn
+            >
+            <v-btn
+              v-if="serverExists"
+              :disabled="deleting"
+              @click="deleteStack"
+              class="mt-2"
+              color="error"
+            >
+              <span v-if="!deleting">Delete Server</span>
+              <span v-else>Deleting...</span>
+            </v-btn>
+          </template>
         </template>
         <component v-else :is="currentView" />
       </v-col>


### PR DESCRIPTION
## Summary
- show a `+ New Server` tab in console
- move server creation form to that tab only
- fix mock `dev_server` response syntax

## Testing
- `npx prettier -w saas_web/components/Console.vue`
- `npx eslint --fix saas_web/components/Console.vue` *(fails: ESLint couldn't find config)*
- `pip install html5validator`
- `html5validator --root saas_web`
- `terraform fmt -recursive`
- `terraform init -backend=false` *(in `saas` and `tenant`)*
- `terraform validate` *(in `saas` and `tenant`)*
- `python dev_server.py` *(started and stopped without issues)*

------
https://chatgpt.com/codex/tasks/task_e_686da9793918832382902ba82d6467d6