### PR TITLE
Fix resource metrics 404

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -79,6 +79,7 @@ if __name__ == "__main__":
             ): (
                 200,
                 {"network_in": 0, "network_out": 0, "volumes": []},
+            ),
             (
                 "GET",
                 "/MC_API/cost",

--- a/saas/lambda/resource_metrics.py
+++ b/saas/lambda/resource_metrics.py
@@ -47,7 +47,8 @@ def handler(event, context):
 
     reservations = resp.get("Reservations", [])
     if not reservations:
-        return {"statusCode": 404, "body": json.dumps({"error": "instance not found"})}
+        body = {"network_in": 0.0, "network_out": 0.0, "volumes": []}
+        return {"statusCode": 200, "body": json.dumps(body)}
 
     instance = reservations[0]["Instances"][0]
     instance_id = instance["InstanceId"]

--- a/saas_web/components/console/DataView.vue
+++ b/saas_web/components/console/DataView.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <h3 class="text-h6 mb-2">Server Metrics</h3>
+    <div v-if="message" class="mb-2 text-error">{{ message }}</div>
     <v-container v-if="loading" class="d-flex justify-center">
       <v-progress-circular indeterminate></v-progress-circular>
     </v-container>
@@ -39,6 +40,7 @@ export default {
       loading: true,
       metrics: { network_in: 0, network_out: 0, volumes: [] },
       apiUrl: "MC_API_URL",
+      message: "",
     };
   },
   methods: {
@@ -66,6 +68,8 @@ export default {
         this.metrics = data;
       } catch (err) {
         console.error(err);
+        this.message = "Failed to fetch server metrics.";
+        this.metrics = { network_in: 0, network_out: 0, volumes: [] };
       } finally {
         this.loading = false;
       }


### PR DESCRIPTION
## Summary
- return empty metrics instead of 404 when server not found
- show an error message in the console metrics view when the API request fails

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `pytest -q` *(fails: ModuleNotFoundError: 'playwright')*
- `python dev_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686da5b72b848323bdf5e9d1a4a67a97