### PR TITLE
Add info logging to tenant API lambdas

### DIFF
--- a/saas/lambda/build_status.py
+++ b/saas/lambda/build_status.py
@@ -15,6 +15,8 @@ def handler(event, context):
     if not build_id:
         return {"statusCode": 400, "body": json.dumps({"error": "missing id"})}
 
+    logger.info("Checking build status for %s", build_id)
+
     try:
         resp = codebuild.batch_get_builds(ids=[build_id])
     except Exception:
@@ -33,4 +35,9 @@ def handler(event, context):
             "current_phase": build.get("currentPhase"),
         }
     }
+    logger.info(
+        "Build %s status retrieved: %s",
+        build.get("id"),
+        build.get("buildStatus"),
+    )
     return {"statusCode": 200, "body": json.dumps(body)}

--- a/saas/lambda/cost_report.py
+++ b/saas/lambda/cost_report.py
@@ -26,6 +26,7 @@ def handler(event, context):
     if not tenant_id:
         logger.error("Missing tenant_id in claims")
         return {"statusCode": 400, "body": json.dumps({"error": "Missing tenant_id"})}
+    logger.info("Generating cost report for tenant %s", tenant_id)
     today = date.today()
     start_date = today.replace(day=1)
     start = start_date.strftime("%Y-%m-%d")
@@ -101,6 +102,11 @@ def handler(event, context):
             )
         except Exception:
             logger.exception("Failed to store cost cache")
+    logger.info(
+        "Cost report generated for tenant %s: total=%s",
+        tenant_id,
+        total,
+    )
     return {
         "statusCode": 200,
         "body": json.dumps({"total": total, "breakdown": breakdown}),

--- a/saas/lambda/create_checkout_session.py
+++ b/saas/lambda/create_checkout_session.py
@@ -21,6 +21,8 @@ def handler(event, context):
     if not tenant_id:
         return {"statusCode": 400, "body": json.dumps({"error": "missing tenant_id"})}
 
+    logger.info("Creating checkout session for tenant %s", tenant_id)
+
     params = urllib.parse.urlencode({
         "metadata[tenant_id]": tenant_id,
     })
@@ -51,6 +53,7 @@ def handler(event, context):
             error_details = intent_data.get("error", {}).get("message", "stripe_error")
             return {"statusCode": 502, "body": json.dumps({"error": error_details})}
         client_secret = intent_data.get("client_secret")
+        logger.info("Checkout session created for tenant %s", tenant_id)
         return {"statusCode": 200, "body": json.dumps({"client_secret": client_secret})}
     except Exception:
         logger.exception("Stripe request failed")

--- a/saas/lambda/delete_stack.py
+++ b/saas/lambda/delete_stack.py
@@ -30,6 +30,12 @@ def handler(event, context):
     if not server_id:
         return {"statusCode": 400, "body": json.dumps({"error": "missing server_id"})}
 
+    logger.info(
+        "Deleting stack for tenant %s server %s",
+        tenant_id,
+        server_id,
+    )
+
     params = [
         {"name": "TENANT_ID", "value": tenant_id, "type": "PLAINTEXT"},
         {"name": "SERVER_ID", "value": server_id, "type": "PLAINTEXT"},
@@ -38,6 +44,7 @@ def handler(event, context):
 
     try:
         codebuild.start_build(projectName=PROJECT_NAME, environmentVariablesOverride=params)
+        logger.info("Destroy build started: tenant %s server %s", tenant_id, server_id)
     except botocore.exceptions.ClientError as e:
         logger.exception(f"ClientError while starting destroy build: {e}")
         return {"statusCode": 500, "body": json.dumps({"error": "AWS ClientError"})}

--- a/saas/lambda/init_server.py
+++ b/saas/lambda/init_server.py
@@ -69,6 +69,14 @@ def handler(event, context):
     if instance_type not in ALLOWED_INSTANCE_TYPES:
         return {"statusCode": 400, "body": json.dumps({"error": "invalid instance_type"})}
 
+    logger.info(
+        "Initializing server %s for tenant %s type=%s instance=%s",
+        server_id,
+        tenant_id,
+        server_type,
+        instance_type,
+    )
+
     try:
         overworld_border = int(body.get("overworld_border", 3000))
     except (TypeError, ValueError):
@@ -111,6 +119,7 @@ def handler(event, context):
         build_resp = codebuild.start_build(
             projectName=PROJECT_NAME, environmentVariablesOverride=params
         )
+        logger.info("Build started for tenant %s server %s", tenant_id, server_id)
     except Exception as e:
         logger.exception("Failed to start build")
         return {
@@ -122,5 +131,6 @@ def handler(event, context):
     body = {"status": "started"}
     if build_id:
         body["build_id"] = build_id
+    logger.info("Init server request queued build %s", build_id)
 
     return {"statusCode": 200, "body": json.dumps(body)}

--- a/saas/lambda/post_user_creation_hook.py
+++ b/saas/lambda/post_user_creation_hook.py
@@ -11,6 +11,8 @@ def handler(event, context):
     user_pool_id = event["userPoolId"]
     username = event["userName"]
 
+    logger.info("Adding tenant_id attribute for user %s", username)
+
     cognito_client = boto3.client("cognito-idp")
 
     try:
@@ -19,6 +21,7 @@ def handler(event, context):
             Username=username,
             UserAttributes=[{"Name": "custom:tenant_id", "Value": str(uuid.uuid4())}],
         )
+        logger.info("Added tenant_id attribute for %s", username)
     except Exception as e:
         logger.error(
             "Failed to update user attributes for user %s in pool %s: %s",

--- a/saas/lambda/resource_metrics.py
+++ b/saas/lambda/resource_metrics.py
@@ -34,6 +34,12 @@ def handler(event, context):
     params = event.get("queryStringParameters") or {}
     server_id = params.get("server_id", "1")
 
+    logger.info(
+        "Fetching resource metrics for tenant %s server %s",
+        tenant_id,
+        server_id,
+    )
+
     try:
         resp = ec2.describe_instances(
             Filters=[
@@ -131,4 +137,12 @@ def handler(event, context):
         )
 
     body = {"network_in": network_in, "network_out": network_out, "volumes": volumes}
+    logger.info(
+        "Metrics for tenant %s server %s: net_in=%s net_out=%s volumes=%d",
+        tenant_id,
+        server_id,
+        network_in,
+        network_out,
+        len(volumes),
+    )
     return {"statusCode": 200, "body": json.dumps(body)}

--- a/saas/lambda/server_status.py
+++ b/saas/lambda/server_status.py
@@ -23,6 +23,12 @@ def handler(event, context):
     params = event.get("queryStringParameters") or {}
     server_id = params.get("server_id", "1")
 
+    logger.info(
+        "Checking server status for tenant %s server %s",
+        tenant_id,
+        server_id,
+    )
+
     try:
         resp = ec2.describe_instances(
             Filters=[
@@ -40,6 +46,14 @@ def handler(event, context):
     if reservations:
         instance = reservations[0]["Instances"][0]
         state = instance.get("State", {}).get("Name", "unknown")
+
+    logger.info(
+        "Server %s for tenant %s exists=%s state=%s",
+        server_id,
+        tenant_id,
+        exists,
+        state,
+    )
 
     return {
         "statusCode": 200,


### PR DESCRIPTION
## Summary
- add info logging statements across tenant API lambda functions

## Testing
- `terraform fmt -recursive`
- `html5validator --root saas_web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dad5bdd3083238d67ebcee964d9b0